### PR TITLE
Zig updates + integer literal fix

### DIFF
--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -52,7 +52,7 @@ pub fn main() !void {
 
     var rust_t = std.mem.tokenize(u8, rustc.stdout, "\n");
     while (rust_t.next()) |target| {
-        try rust_targets.put(target, .{});
+        try rust_targets.put(target, {});
     }
     for (static_list) |target| {
         try rust_targets.put(target, {});
@@ -322,7 +322,7 @@ const FeatureIterator = struct {
 
     pub fn next(self: *Self) ?Set.Index {
         // no ffs, so ctz+1
-        const ffs = @intCast(usize, @ctz(usize, self.current));
+        const ffs = @intCast(usize, @ctz(self.current));
         if (ffs >= @bitSizeOf(usize)) {
             // have we checked the whole array?
             if (self.ints_indx == 0) return null;
@@ -350,7 +350,7 @@ pub fn featureIndexIterator(set: Set) FeatureIterator {
 pub fn count(set: Set) usize {
     var ret: usize = 0;
     for (set.ints) |i| {
-        ret += @popCount(usize, i);
+        ret += @popCount(i);
     }
     return ret;
 }

--- a/repc/arocc/src/c.rs
+++ b/repc/arocc/src/c.rs
@@ -274,7 +274,13 @@ impl Generator {
     #[allow(clippy::many_single_char_names)]
     fn emit_expr(&mut self, e: &Expr) -> Result<()> {
         match &e.ty {
-            ExprType::Lit(v) => write!(self.current, "{}", v)?,
+            ExprType::Lit(v) => if v > &9223372036854775807 {
+                write!(self.current, "{}ULL", v)?
+            } else {
+                write!(self.current, "{}", v)?
+            },
+
+
             ExprType::Name(n) => write!(self.current, "{}", n)?,
             ExprType::Unary(k, v) => {
                 let s = match k {


### PR DESCRIPTION
Update `RustToZigTargets.zig` to compile with the latest version of Zig

Add `ULL` suffix to integer literals which require them, to prevent spurious warnings in the arocc layout test runner.