### PR TITLE
A few small updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "anyhow",
  "cly-impl",
  "gimli",
+ "itertools",
  "object",
  "pdb",
  "rayon",
@@ -253,6 +254,15 @@ name = "isnt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a7558cc96ddcaf0b4144d7149984ace2899bb29d4ee2999979d429efc305200"
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "itertools",
  "object",
  "pdb",
+ "rand 0.8.5",
  "rayon",
  "repc-impl",
  "repc-tests",
@@ -214,6 +215,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,9 +284,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "memoffset"
@@ -325,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +374,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +408,15 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"
@@ -498,7 +546,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand",
+ "rand 0.4.6",
  "remove_dir_all",
 ]
 
@@ -543,6 +591,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "cly-impl",
  "gimli",
  "itertools",
+ "lazy_static",
  "object",
  "pdb",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
+name = "arocc-test-gen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cly-impl",
+ "gimli",
+ "object",
+ "pdb",
+ "rayon",
+ "repc-impl",
+ "repc-tests",
+ "serde",
+ "tempdir",
+ "toml",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "cly/impl",
     "repc/facade",
     "repc/test-generator",
+    "repc/arocc",
     "repc/impl",
     "repc/tests",
 ]

--- a/cly/impl/src/converter.rs
+++ b/cly/impl/src/converter.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::ops::Not;
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct ConversionResult {
     pub types: HashMap<String, Type<TypeLayout>>,
     pub consts: HashMap<String, i128>,

--- a/repc/arocc/.gitignore
+++ b/repc/arocc/.gitignore
@@ -1,0 +1,5 @@
+zig-cache/
+zig-out/
+# this build file is only to make neovim's zig LSP work better
+# the project doesn't need it
+build.zig

--- a/repc/arocc/Cargo.toml
+++ b/repc/arocc/Cargo.toml
@@ -8,11 +8,13 @@ itertools = "0.10.3"
 repc-tests = { path = "../tests" }
 repc-impl = { path = "../impl" }
 cly-impl = { path = "../../cly/impl" }
+# generator = { path = "../test-generator" }
 anyhow =  "1.0.38"
 tempdir = "0.3.7"
 serde = { version = "1.0.120", features = ["derive"] }
 toml = "0.5.8"
 rayon = "1.5.0"
+rand  = "0.8.5"
 gimli = "0.23.0"
 pdb = { git = "https://github.com/willglynn/pdb.git", rev = "01025d3a8ef9fcad814fa741adabb0396c29ca7d" }
 object = { git = "https://github.com/mahkoh/object.git", rev = "bddaeeac024b46c64ba92b62077d762e6631c993", features = ["coff"] }

--- a/repc/arocc/Cargo.toml
+++ b/repc/arocc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+lazy_static = "1.4.0"
 itertools = "0.10.3"
 repc-tests = { path = "../tests" }
 repc-impl = { path = "../impl" }

--- a/repc/arocc/Cargo.toml
+++ b/repc/arocc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "arocc-test-gen"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+repc-tests = { path = "../tests" }
+repc-impl = { path = "../impl" }
+cly-impl = { path = "../../cly/impl" }
+anyhow =  "1.0.38"
+tempdir = "0.3.7"
+serde = { version = "1.0.120", features = ["derive"] }
+toml = "0.5.8"
+rayon = "1.5.0"
+gimli = "0.23.0"
+pdb = { git = "https://github.com/willglynn/pdb.git", rev = "01025d3a8ef9fcad814fa741adabb0396c29ca7d" }
+object = { git = "https://github.com/mahkoh/object.git", rev = "bddaeeac024b46c64ba92b62077d762e6631c993", features = ["coff"] }

--- a/repc/arocc/Cargo.toml
+++ b/repc/arocc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+itertools = "0.10.3"
 repc-tests = { path = "../tests" }
 repc-impl = { path = "../impl" }
 cly-impl = { path = "../../cly/impl" }

--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -1,0 +1,289 @@
+// at attemp to convert between rust and zig targets.
+// rustc must be in the path.
+// compile with `zig build-exe RustToZigTgarets.zig
+
+const std = @import("std");
+const CrossTarget = std.zig.CrossTarget;
+var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+const Target = std.Target;
+const Arch = std.Target.Cpu.Arch;
+const Cpu = std.Target.Cpu;
+const Model = std.Target.Cpu.Model;
+const Feature = std.Target.Cpu.Feature;
+const Set = std.Target.Cpu.Feature.Set;
+const Os = std.Target.Os;
+const Abi = std.Target.Abi;
+
+const FindTarget = struct {
+    arch: ?Arch = null,
+    model: ?*const Model = null,
+    os: ?Os.Tag = null,
+    abi: ?Abi = null,
+};
+
+pub fn main() !void {
+    const gpa = general_purpose_allocator.allocator();
+    defer if (general_purpose_allocator.deinit()) std.process.exit(1);
+
+    const res = try std.ChildProcess.exec(.{ .allocator = gpa, .argv = &.{
+        "rustc",
+        "--print",
+        "target-list",
+    } });
+
+    var targets = std.mem.tokenize(u8, res.stdout, "\n");
+    while (targets.next()) |target| {
+        var fill = FindTarget{};
+
+        std.debug.print("{s}\n", .{target});
+        var ittr = std.mem.tokenize(u8, target, "-");
+        while (ittr.next()) |part| {
+            if (std.ascii.eqlIgnoreCase(part, "unknown")) continue;
+            searchArch(part, &fill);
+            searchModel(part, &fill);
+            searchOs(part, &fill);
+            searchAbi(part, &fill);
+        }
+        // ok. see if we can make a useful target out of all of this.
+        if (fill.arch) |arch| {
+            const end_tag = fill.os orelse Os.Tag.other;
+            const end_os = Os{
+                .tag = end_tag,
+                .version_range = Os.VersionRange.default(end_tag, arch),
+            };
+            const end_model = fill.model orelse Model.generic(arch);
+            const end_abi = fill.abi orelse Abi.default(arch, end_os);
+
+            const result = Target{
+                .cpu = .{
+                    .arch = arch,
+                    .model = end_model,
+                    .features = end_model.features,
+                },
+                .os = end_os,
+                .abi = end_abi,
+            };
+            std.debug.print("\t{s}-{s}-{s}-{s}\n", .{
+                @tagName(result.cpu.arch),
+                result.cpu.model.name,
+                @tagName(result.os.tag),
+                @tagName(result.abi),
+            });
+        } else {
+            std.debug.print("\tno arch for target\n", .{});
+            continue;
+        }
+    }
+    gpa.free(res.stdout);
+    gpa.free(res.stderr);
+}
+
+fn searchAbi(text: []const u8, res: *FindTarget) void {
+    if (res.abi != null) return;
+    inline for (@typeInfo(Abi).Enum.fields) |fld| {
+        if (std.ascii.eqlIgnoreCase(fld.name, text)) {
+            res.abi = @intToEnum(Target.Abi, fld.value);
+            return;
+        }
+    }
+}
+
+fn searchOs(text: []const u8, res: *FindTarget) void {
+    if (res.os != null) return;
+    if (std.ascii.eqlIgnoreCase("darwin", text)) {
+        res.os = Os.Tag.macos;
+        if (res.arch.? == .i386) {
+            // i686 etc is ambgious. can be both 32 or 64 bit
+            // but macos is only 64 bit.
+            std.debug.print("\tswap.\n", .{});
+            res.arch = Arch.x86_64;
+        }
+        return;
+    }
+    inline for (@typeInfo(Os.Tag).Enum.fields) |fld| {
+        if (std.ascii.eqlIgnoreCase(fld.name, text)) {
+            res.os = @intToEnum(Target.Os.Tag, fld.value);
+            if (res.os.? == .macos and res.arch.? == .i386) {
+                // i686 etc is ambgious. can be both 32 or 64 bit
+                // but macos is only 64 bit.
+                std.debug.print("\tswap.\n", .{});
+                res.arch = Arch.x86_64;
+            }
+            return;
+        }
+    }
+}
+
+fn searchModel(text: []const u8, res: *FindTarget) void {
+    if (res.model != null or res.arch == null) return;
+    for (res.arch.?.allCpuModels()) |mod| {
+        if (mod.llvm_name) |ll| {
+            if (std.ascii.eqlIgnoreCase(ll, text)) {
+                res.model = mod;
+                return;
+            }
+        }
+    }
+}
+
+fn searchArch(text: []const u8, res: *FindTarget) void {
+    if (res.arch != null) return;
+    // look for an exact match.
+    if (std.meta.stringToEnum(Arch, text)) |a| {
+        res.arch = a;
+        return;
+    }
+
+    // rust targets like armebv7r-none-eabi have both the arch and the cpu
+    // in the "target" part of the string. Walk the string backwards and see
+    // if ther is a arch in there.
+
+    var end = text.len - 1;
+    // no arch less than 3 long
+    while (end > 2) : (end -= 1) {
+        if (std.meta.stringToEnum(Arch, text[0..end])) |a| {
+            // fount it.
+            res.arch = a;
+
+            const maybeModel = text[end..];
+            if (maybeModel.len <= 0) return;
+
+            // search for CPU model in the end of the string.
+
+            for (a.allCpuModels()) |mod| {
+                const ll = mod.llvm_name orelse continue;
+                if (std.ascii.eqlIgnoreCase(ll, maybeModel)) {
+                    res.model = mod;
+                    return;
+                }
+            }
+            // hmm... maybe it's a feature name.
+            res.model = searchFeatures(text, a);
+            if (res.model == null) {
+                // sometines only the end part is a feature
+                // std.debug.print(" l:{s} ", .{maybeModel});
+                res.model = searchFeatures(maybeModel, a);
+            }
+            return;
+        }
+    }
+
+    if (res.arch == null) {
+        // sometimes the first part of the triplet is a cpu model
+        // like i686
+        // because i386 comes before x86_64 in the enum,
+        // i686 etc will default to 32-bit (i386)
+        // it's ambgious.. so.. seems safe?
+        for (std.enums.values(Arch)) |a| {
+            for (a.allCpuModels()) |mod| {
+                const ll = mod.llvm_name orelse continue;
+                if (std.ascii.eqlIgnoreCase(text, ll)) {
+                    res.arch = a;
+                    res.model = mod;
+                    return;
+                }
+            }
+        }
+    }
+    return;
+}
+
+fn searchFeatures(text: []const u8, arch: Arch) ?*const Model {
+    var ret: ?*const Model = null;
+    for (arch.allFeaturesList()) |feat| {
+        if (feat.llvm_name) |ll| {
+            if (std.ascii.eqlIgnoreCase(ll, text)) {
+                var max: usize = std.math.maxInt(usize);
+                for (arch.allCpuModels()) |mod| {
+                    var f_count: usize = 0;
+                    if (hasFeature(mod, feat, arch, &f_count)) {
+                        if (f_count < max) {
+                            ret = mod;
+                            max = f_count;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return ret;
+}
+const FeatureIterator = struct {
+    const Self = @This();
+    set: *const Set,
+    ints_indx: usize,
+    current: usize,
+
+    pub fn next(self: *Self) ?Set.Index {
+        // no ffs, so ctz+1
+        const ffs = @intCast(usize, @ctz(usize, self.current));
+        if (ffs >= @bitSizeOf(usize)) {
+            // have we checked the whole array?
+            if (self.ints_indx == 0) return null;
+            // load the next one and try again
+            self.ints_indx -= 1;
+            self.current = self.set.ints[self.ints_indx];
+            return @call(.{ .modifier = .always_tail }, next, .{self});
+        }
+        // clear the bit we're about to return
+        self.current &= (self.current - 1);
+        const ret = ffs + (@bitSizeOf(usize) * (self.ints_indx));
+        return @intCast(Set.Index, ret);
+    }
+};
+
+pub fn featureIndexIterator(set: Set) FeatureIterator {
+    return FeatureIterator{
+        .set = &set,
+        .ints_indx = set.ints.len - 1,
+        .current = set.ints[set.ints.len - 1],
+    };
+}
+
+/// how many features in this set
+pub fn count(set: Set) usize {
+    var ret: usize = 0;
+    for (set.ints) |i| {
+        ret += @popCount(usize, i);
+    }
+    return ret;
+}
+/// a union of all the features and their dependencies.
+pub fn featuresUnion(model: *const Model, arch: Arch, result: *Feature.Set) void {
+    // start empty
+    std.mem.set(usize, &result.ints, 0);
+    walkFeatures(model.features, arch, result);
+}
+fn walkFeatures(node: Feature.Set, arch: Arch, result: *Feature.Set) void {
+    for (result.ints) |*item, idx| {
+        item.* |= node.ints[idx];
+    }
+    var itr = featureIndexIterator(node);
+    while (itr.next()) |f_index| {
+        const next_node = arch.allFeaturesList()[f_index];
+        if (!next_node.dependencies.isEmpty()) {
+            // if there is a loop in this graph, this will
+            // blow the stack. But 'zig targets' runs, and that
+            // dumps the whole graph.
+            walkFeatures(next_node.dependencies, arch, result);
+        }
+    }
+}
+
+pub fn hasFeature(model: *const Model, feature: Feature, arch: Arch, f_count: ?*usize) bool {
+    if (model.features.isEnabled(feature.index)) return true;
+    var feat_union: Feature.Set = undefined;
+    featuresUnion(model, arch, &feat_union);
+    if (f_count) |c| {
+        c.* = count(feat_union);
+    }
+    return feat_union.isEnabled(feature.index);
+}
+
+test "while" {
+    var c: usize = 0;
+    while (c < 100) : (c += 1) {
+        if (c == 22) break;
+    }
+    std.debug.assert(c == 22);
+}

--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -100,7 +100,15 @@ fn resolveTarget(target: []const u8, writer: anytype) !bool {
     var fill: FindTarget = .{};
 
     // std.debug.print("{s} || ", .{target});
-    var ittr = std.mem.tokenize(u8, target, "-");
+    var ittr = std.mem.split(u8, target, "-");
+    var last: []const u8 = undefined;
+    while (ittr.next()) |part| {
+        last = part;
+    }
+    if (eqlIgnoreCase(last, "none")) {
+        fill.abi = .none;
+    }
+    ittr.reset();
     while (ittr.next()) |part| {
         if (eqlIgnoreCase(part, "unknown") or eqlIgnoreCase(part, "none")) continue;
         if (isUnknown(part)) {

--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -62,7 +62,7 @@ pub fn main() !void {
         const key = entry.key_ptr.*;
         var z_target = try gpa.alloc(u8, 128);
         var strm = std.io.fixedBufferStream(z_target);
-        if (try resloveTarget(key, strm.writer())) {
+        if (try resolveTarget(key, strm.writer())) {
             const ent = try mapping.getOrPut(strm.getWritten());
             if (!ent.found_existing) {
                 ent.value_ptr.* = std.ArrayList([]const u8).init(gpa);
@@ -96,7 +96,7 @@ pub fn main() !void {
         gpa.free(k);
     }
 }
-fn resloveTarget(target: []const u8, writer: anytype) !bool {
+fn resolveTarget(target: []const u8, writer: anytype) !bool {
     var fill: FindTarget = .{};
 
     // std.debug.print("{s} || ", .{target});

--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -41,13 +41,13 @@ pub fn main() !void {
 
     // make a unique list from rustc as well
     // has the hard-coded targets from repr-c
-    var rust_targets = std.StringHashMap(void).init(gpa);
+    var rust_targets = std.StringArrayHashMap(void).init(gpa);
     defer rust_targets.deinit();
     // mutiple rust targets can map to the same
     // zig target. Keep track of the mappings
     // so we can find and eliminate these rust
     // targets
-    var mapping = std.StringHashMap(std.ArrayList([]const u8)).init(gpa);
+    var mapping = std.StringArrayHashMap(std.ArrayList([]const u8)).init(gpa);
     defer mapping.deinit();
 
     var rust_t = std.mem.tokenize(u8, rustc.stdout, "\n");
@@ -57,28 +57,30 @@ pub fn main() !void {
     for (static_list) |target| {
         try rust_targets.put(target, {});
     }
-    var it = rust_targets.keyIterator();
-    while (it.next()) |rt| {
+    var it = rust_targets.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
         var z_target = try gpa.alloc(u8, 128);
         var strm = std.io.fixedBufferStream(z_target);
-        if (try resloveTarget(rt.*, strm.writer())) {
+        if (try resloveTarget(key, strm.writer())) {
             const ent = try mapping.getOrPut(strm.getWritten());
             if (!ent.found_existing) {
                 ent.value_ptr.* = std.ArrayList([]const u8).init(gpa);
             } else {
                 gpa.free(z_target);
             }
-            try ent.value_ptr.append(rt.*);
+            try ent.value_ptr.append(key);
         } else {
             gpa.free(z_target);
-            std.debug.print("no target for {s}\n", .{rt.*});
+            std.debug.print("no target for {s}\n", .{key});
         }
     }
-    var k_itr = mapping.keyIterator();
-    while (k_itr.next()) |k| {
-        const v = mapping.get(k.*).?;
+    var k_itr = mapping.iterator();
+    while (k_itr.next()) |entry| {
+        const k = entry.key_ptr.*;
+        const v = entry.value_ptr.*;
         if (v.items.len > 1) {
-            std.debug.print("multi {s} : ", .{k.*});
+            std.debug.print("multi {s} : ", .{k});
             for (v.items) |i| {
                 std.debug.print(" {s}", .{i});
             }
@@ -87,11 +89,11 @@ pub fn main() !void {
 
         for (v.items) |t| {
             // safe to output
-            try out.print("{s}:{s}\n", .{ t, k.* });
+            try out.print("{s}:{s}\n", .{ t, k });
             // std.debug.print("single {s} : {s}\n", .{ k.*, v.items[0] });
         }
         v.deinit();
-        gpa.free(k.*);
+        gpa.free(k);
     }
 }
 fn resloveTarget(target: []const u8, writer: anytype) !bool {

--- a/repc/arocc/RustToZigTargets.zig
+++ b/repc/arocc/RustToZigTargets.zig
@@ -52,7 +52,7 @@ pub fn main() !void {
 
     var rust_t = std.mem.tokenize(u8, rustc.stdout, "\n");
     while (rust_t.next()) |target| {
-        try rust_targets.put(target, .{});
+        try rust_targets.put(target, {});
     }
     for (static_list) |target| {
         try rust_targets.put(target, {});
@@ -322,7 +322,7 @@ const FeatureIterator = struct {
 
     pub fn next(self: *Self) ?Set.Index {
         // no ffs, so ctz+1
-        const ffs = @intCast(usize, @ctz(usize, self.current));
+        const ffs = @intCast(usize, @ctz(self.current));
         if (ffs >= @bitSizeOf(usize)) {
             // have we checked the whole array?
             if (self.ints_indx == 0) return null;
@@ -350,7 +350,7 @@ pub fn featureIndexIterator(set: Set) FeatureIterator {
 pub fn count(set: Set) usize {
     var ret: usize = 0;
     for (set.ints) |i| {
-        ret += @popCount(usize, i);
+        ret += @popCount(i);
     }
     return ret;
 }

--- a/repc/arocc/src/c.rs
+++ b/repc/arocc/src/c.rs
@@ -274,12 +274,13 @@ impl Generator {
     #[allow(clippy::many_single_char_names)]
     fn emit_expr(&mut self, e: &Expr) -> Result<()> {
         match &e.ty {
-            ExprType::Lit(v) => if v > &9223372036854775807 {
-                write!(self.current, "{}ULL", v)?
-            } else {
-                write!(self.current, "{}", v)?
-            },
-
+            ExprType::Lit(v) => {
+                if v > &9223372036854775807 {
+                    write!(self.current, "{}ULL", v)?
+                } else {
+                    write!(self.current, "{}", v)?
+                }
+            }
 
             ExprType::Name(n) => write!(self.current, "{}", n)?,
             ExprType::Unary(k, v) => {

--- a/repc/arocc/src/c.rs
+++ b/repc/arocc/src/c.rs
@@ -96,7 +96,7 @@ impl Generator {
             writeln!(self.current, "#pragma pack()")?;
         }
 
-        writeln!(self.current, "struct {}_alignment {{", name)?;
+        writeln!(self.current, "struct {}_extra_alignment {{", name)?;
         if self.compiler == Compiler::Msvc {
             writeln!(self.current, "    char a[_Alignof({})];", name)?;
             writeln!(self.current, "    char b;")?;
@@ -106,39 +106,39 @@ impl Generator {
         }
         writeln!(self.current, "}};")?;
         let id = self.generate_id();
-        writeln!(self.current, "struct {}_alignment var{};", name, id)?;
+        writeln!(self.current, "struct {}_extra_alignment var{};", name, id)?;
 
         writeln!(self.current, "#pragma pack(1)")?;
-        writeln!(self.current, "struct {}_packed {{", name)?;
+        writeln!(self.current, "struct {}_extra_packed {{", name)?;
         writeln!(self.current, "    {} a;", name)?;
         writeln!(self.current, "}};")?;
         writeln!(self.current, "#pragma pack()")?;
-        writeln!(self.current, "struct {}_required_alignment {{", name)?;
+        writeln!(self.current, "struct {}_extra_required_alignment {{", name)?;
         if self.compiler == Compiler::Msvc {
             writeln!(
                 self.current,
-                "    char a[_Alignof(struct {}_packed)];",
+                "    char a[_Alignof(struct {}_extra_packed)];",
                 name
             )?;
             writeln!(self.current, "    char b;")?;
         } else {
             writeln!(self.current, "    char a;")?;
-            writeln!(self.current, "    struct {}_packed b;", name)?;
+            writeln!(self.current, "    struct {}_extra_packed b;", name)?;
         }
         writeln!(self.current, "}};")?;
         let id = self.generate_id();
         writeln!(
             self.current,
-            "struct {}_required_alignment var{};",
+            "struct {}_extra_required_alignment var{};",
             name, id
         )?;
 
-        writeln!(self.current, "struct {}_size {{", name)?;
+        writeln!(self.current, "struct {}_extra_size {{", name)?;
         writeln!(self.current, "    char a[sizeof({})+1];", name)?;
         writeln!(self.current, "    char b;")?;
         writeln!(self.current, "}};")?;
         let id = self.generate_id();
-        writeln!(self.current, "struct {}_size var{};", name, id)?;
+        writeln!(self.current, "struct {}_extra_size var{};", name, id)?;
 
         writeln!(self.output, "{}", self.current)?;
         self.current = self.stack.pop().unwrap();

--- a/repc/arocc/src/c.rs
+++ b/repc/arocc/src/c.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+use anyhow::bail;
+use anyhow::Result;
+use cly_impl::ast::{
+    Annotation, Array, BinaryExprType, BuiltinExpr, Declaration, DeclarationType, Expr, ExprType,
+    Record, RecordField, Type, TypeExprType, TypeVariant, UnaryExprType,
+};
+use repc_impl::layout::{BuiltinType, RecordKind};
+use repc_impl::target::Compiler;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::mem;
+
+pub(crate) fn generate(
+    i: &[Declaration],
+    compiler: Compiler,
+) -> Result<(String, HashMap<usize, String>)> {
+    let mut g = Generator {
+        next: 1,
+        ids: Default::default(),
+        output: "".to_string(),
+        current: "".to_string(),
+        stack: vec![],
+        compiler,
+    };
+    g.generate(i)?;
+    Ok((g.output, g.ids))
+}
+
+struct Generator {
+    next: usize,
+    ids: HashMap<usize, String>,
+    output: String,
+    current: String,
+    stack: Vec<String>,
+    compiler: Compiler,
+}
+
+impl Generator {
+    fn generate(&mut self, d: &[Declaration]) -> Result<()> {
+        for d in d {
+            match &d.ty {
+                DeclarationType::Type(t) => self.emit_type_decl(&d.name, t)?,
+                DeclarationType::Const(c) => self.emit_const(&d.name, c)?,
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_const(&mut self, name: &str, c: &Expr) -> Result<()> {
+        self.stack
+            .push(mem::replace(&mut self.current, String::new()));
+        write!(self.current, "#define {} ", name)?;
+        self.emit_expr(c)?;
+        writeln!(self.output, "{}", self.current)?;
+        self.current = self.stack.pop().unwrap();
+        Ok(())
+    }
+
+    fn generate_id(&mut self) -> usize {
+        let next = self.next;
+        self.next += 1;
+        next
+    }
+
+    fn emit_type_decl(&mut self, name: &str, t: &Type) -> Result<()> {
+        assert!(self.ids.insert(t.id, name.to_string()).is_none());
+        self.stack
+            .push(mem::replace(&mut self.current, String::new()));
+        let annotations = get_unique_annotations(&t.annotations)?;
+        if let Some(p) = annotations.pragma_pack {
+            write!(self.current, "#pragma pack(")?;
+            self.emit_expr(p)?;
+            writeln!(self.current, ")")?;
+        }
+        if self.compiler == Compiler::Msvc {
+            if let Some(p) = annotations.align {
+                match p {
+                    Some(p) => self.emit_declspec_align(p)?,
+                    _ => bail!("MSVC does not support @align without a value"),
+                }
+            }
+        }
+        match &t.variant {
+            TypeVariant::Builtin(_) => bail!("builtin types cannot be declared"),
+            TypeVariant::Record(r) => self.emit_record(name, &annotations, r)?,
+            TypeVariant::Typedef(r) => self.emit_typedef(name, &annotations, r)?,
+            TypeVariant::Array(a) => self.emit_array(name, &annotations, a)?,
+            TypeVariant::Opaque(_) => bail!("opaque types cannot be declared"),
+            TypeVariant::Name(..) => bail!("names cannot be declared"),
+            TypeVariant::Enum(r) => self.emit_enum(name, &annotations, r)?,
+        }
+        let id = self.generate_id();
+        writeln!(self.current, "{} var{};", name, id)?;
+        if annotations.pragma_pack.is_some() {
+            writeln!(self.current, "#pragma pack()")?;
+        }
+
+        writeln!(self.current, "struct {}_alignment {{", name)?;
+        if self.compiler == Compiler::Msvc {
+            writeln!(self.current, "    char a[_Alignof({})];", name)?;
+            writeln!(self.current, "    char b;")?;
+        } else {
+            writeln!(self.current, "    char a;")?;
+            writeln!(self.current, "    {} b;", name)?;
+        }
+        writeln!(self.current, "}};")?;
+        let id = self.generate_id();
+        writeln!(self.current, "struct {}_alignment var{};", name, id)?;
+
+        writeln!(self.current, "#pragma pack(1)")?;
+        writeln!(self.current, "struct {}_packed {{", name)?;
+        writeln!(self.current, "    {} a;", name)?;
+        writeln!(self.current, "}};")?;
+        writeln!(self.current, "#pragma pack()")?;
+        writeln!(self.current, "struct {}_required_alignment {{", name)?;
+        if self.compiler == Compiler::Msvc {
+            writeln!(
+                self.current,
+                "    char a[_Alignof(struct {}_packed)];",
+                name
+            )?;
+            writeln!(self.current, "    char b;")?;
+        } else {
+            writeln!(self.current, "    char a;")?;
+            writeln!(self.current, "    struct {}_packed b;", name)?;
+        }
+        writeln!(self.current, "}};")?;
+        let id = self.generate_id();
+        writeln!(
+            self.current,
+            "struct {}_required_alignment var{};",
+            name, id
+        )?;
+
+        writeln!(self.current, "struct {}_size {{", name)?;
+        writeln!(self.current, "    char a[sizeof({})+1];", name)?;
+        writeln!(self.current, "    char b;")?;
+        writeln!(self.current, "}};")?;
+        let id = self.generate_id();
+        writeln!(self.current, "struct {}_size var{};", name, id)?;
+
+        writeln!(self.output, "{}", self.current)?;
+        self.current = self.stack.pop().unwrap();
+        Ok(())
+    }
+
+    fn emit_record(&mut self, n: &str, a: &Annotations, r: &Record) -> Result<()> {
+        let kind = match r.kind {
+            RecordKind::Struct => "struct",
+            RecordKind::Union => "union",
+        };
+        writeln!(self.current, "typedef {} {{", kind)?;
+        for f in &r.fields {
+            self.emit_record_field(f)?;
+        }
+        write!(self.current, "}}")?;
+        self.emit_gcc_attributes(a)?;
+        writeln!(self.current, " {};", n)?;
+        Ok(())
+    }
+
+    fn emit_enum(&mut self, n: &str, a: &Annotations, e: &[Expr]) -> Result<()> {
+        writeln!(self.current, "typedef enum {{")?;
+        for e in e.iter() {
+            let idx = self.generate_id();
+            write!(self.current, "    F{} = ", idx)?;
+            self.emit_expr(e)?;
+            writeln!(self.current, ",")?;
+        }
+        write!(self.current, "}}")?;
+        self.emit_gcc_attributes(a)?;
+        writeln!(self.current, " {};", n)?;
+        Ok(())
+    }
+
+    fn emit_array(&mut self, n: &str, an: &Annotations, a: &Array) -> Result<()> {
+        write!(self.current, "typedef ")?;
+        self.emit_type_name(&a.element_type)?;
+        write!(self.current, " {}[", n)?;
+        if let Some(v) = &a.num_elements {
+            self.emit_expr(v)?;
+        } else if self.compiler != Compiler::Msvc {
+            write!(self.current, "0")?;
+        }
+        write!(self.current, "]")?;
+        self.emit_gcc_attributes(an)?;
+        writeln!(self.current, ";")?;
+        Ok(())
+    }
+
+    fn emit_typedef(&mut self, n: &str, a: &Annotations, u: &Type) -> Result<()> {
+        write!(self.current, "typedef ")?;
+        self.emit_type_name(u)?;
+        write!(self.current, " {}", n)?;
+        self.emit_gcc_attributes(a)?;
+        writeln!(self.current, ";")?;
+        Ok(())
+    }
+
+    fn emit_gcc_attributes(&mut self, a: &Annotations) -> Result<()> {
+        if self.compiler != Compiler::Msvc {
+            match a.align {
+                Some(Some(a)) => {
+                    write!(self.current, " __attribute__((aligned(")?;
+                    self.emit_expr(a)?;
+                    write!(self.current, ")))")?;
+                }
+                Some(None) => write!(self.current, " __attribute__((aligned))")?,
+                _ => {}
+            }
+        }
+        if a.attr_packed {
+            write!(self.current, " __attribute__((packed))")?;
+        }
+        Ok(())
+    }
+
+    fn emit_builtin_type(&mut self, bi: BuiltinType) -> Result<()> {
+        use BuiltinType::*;
+        let s = match bi {
+            Unit | U8 | U16 | U32 | U64 | I8 | I16 | I32 | I64 | F32 | F64 => {
+                bail!("type {:?} cannot be used", bi)
+            }
+            I128 => "__int128",
+            U128 => "unsigned __int128",
+            Bool => "_Bool",
+            Char => "char",
+            SignedChar => "signed char",
+            UnsignedChar => "unsigned char",
+            Short => "short",
+            UnsignedShort => "unsigned short",
+            Int => "int",
+            UnsignedInt => "unsigned int",
+            Long => "long",
+            UnsignedLong => "unsigned long",
+            LongLong => "long long",
+            UnsignedLongLong => "unsigned long long",
+            Float => "float",
+            Double => "double",
+            Pointer => "void*",
+        };
+        write!(self.current, "{}", s)?;
+        Ok(())
+    }
+
+    fn emit_record_field(&mut self, f: &RecordField) -> Result<()> {
+        let annotations = get_unique_annotations(&f.annotations)?;
+        if annotations.pragma_pack.is_some() {
+            bail!("pragma pack cannot be used on fields");
+        }
+        write!(self.current, "    ")?;
+        if self.compiler == Compiler::Msvc {
+            if let Some(a) = annotations.align {
+                match a {
+                    Some(a) => self.emit_declspec_align(a)?,
+                    _ => bail!("MSVC doesn't support @align without a value"),
+                }
+            }
+        }
+        self.emit_type_name(&f.ty)?;
+        if let Some(n) = &f.name {
+            write!(self.current, " {}", n)?;
+        }
+        if let Some(bw) = &f.bit_width {
+            write!(self.current, ":")?;
+            self.emit_expr(bw)?;
+        }
+        self.emit_gcc_attributes(&annotations)?;
+        writeln!(self.current, ";")?;
+        Ok(())
+    }
+
+    #[allow(clippy::many_single_char_names)]
+    fn emit_expr(&mut self, e: &Expr) -> Result<()> {
+        match &e.ty {
+            ExprType::Lit(v) => write!(self.current, "{}", v)?,
+            ExprType::Name(n) => write!(self.current, "{}", n)?,
+            ExprType::Unary(k, v) => {
+                let s = match k {
+                    UnaryExprType::Neg => "-",
+                    UnaryExprType::Not => "!",
+                };
+                write!(self.current, "{}", s)?;
+                self.emit_expr(v)?;
+            }
+            ExprType::Binary(k, l, r) => {
+                self.emit_expr(l)?;
+                let s = match k {
+                    BinaryExprType::Add => "+",
+                    BinaryExprType::Sub => "-",
+                    BinaryExprType::Mul => "*",
+                    BinaryExprType::Div => "/",
+                    BinaryExprType::Mod => "%",
+                    BinaryExprType::LogicalAnd => "&&",
+                    BinaryExprType::LogicalOr => "||",
+                    BinaryExprType::Eq => "==",
+                    BinaryExprType::NotEq => "!=",
+                    BinaryExprType::Lt => "<",
+                    BinaryExprType::Le => "<=",
+                    BinaryExprType::Gt => ">",
+                    BinaryExprType::Ge => ">=",
+                };
+                write!(self.current, " {} ", s)?;
+                self.emit_expr(r)?;
+            }
+            ExprType::TypeExpr(k, t) => {
+                write!(self.current, "(sizeof(")?;
+                self.emit_type_name(t)?;
+                write!(self.current, ")")?;
+                if *k == TypeExprType::SizeofBits {
+                    write!(self.current, "*8")?;
+                }
+                write!(self.current, ")")?;
+            }
+            ExprType::Builtin(bi) => match bi {
+                BuiltinExpr::BitsPerByte => write!(self.current, "8")?,
+            },
+            ExprType::Offsetof(_, _, _) => bail!("cannot emit offsetof"),
+        }
+        Ok(())
+    }
+
+    fn emit_type_name(&mut self, ty: &Type) -> Result<()> {
+        use TypeVariant::*;
+        match &ty.variant {
+            Name(n, _) => write!(self.current, "{}", n)?,
+            Builtin(bi) => self.emit_builtin_type(*bi)?,
+            _ => {
+                let name = format!("unnamed_type_{}", self.generate_id());
+                self.emit_type_decl(&name, &ty)?;
+                write!(self.current, "{}", name)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_declspec_align(&mut self, e: &Expr) -> Result<()> {
+        write!(self.current, "__declspec(align(")?;
+        self.emit_expr(e)?;
+        write!(self.current, ")) ")?;
+        Ok(())
+    }
+}
+
+struct Annotations<'a> {
+    align: Option<Option<&'a Expr>>,
+    attr_packed: bool,
+    pragma_pack: Option<&'a Expr>,
+}
+
+fn get_unique_annotations(a: &[Annotation]) -> Result<Annotations> {
+    let mut align = None;
+    let mut attr_packed = false;
+    let mut pragma_pack = None;
+    for a in a {
+        match a {
+            Annotation::PragmaPack(n) => {
+                if pragma_pack.is_some() {
+                    bail!("cannot used multiple pragma pack annotations");
+                }
+                pragma_pack = Some(&**n);
+            }
+            Annotation::AttrPacked => attr_packed = true,
+            Annotation::Aligned(n) => {
+                if align.is_some() {
+                    bail!("cannot used multiple align annotations");
+                }
+                align = Some(n.as_ref().map(|n| &**n));
+            }
+        }
+    }
+    Ok(Annotations {
+        align,
+        attr_packed,
+        pragma_pack,
+    })
+}

--- a/repc/arocc/src/c.rs
+++ b/repc/arocc/src/c.rs
@@ -274,7 +274,13 @@ impl Generator {
     #[allow(clippy::many_single_char_names)]
     fn emit_expr(&mut self, e: &Expr) -> Result<()> {
         match &e.ty {
-            ExprType::Lit(v) => write!(self.current, "{}", v)?,
+            ExprType::Lit(v) => if v > &9223372036854775807 {
+                write!(self.current, "{}ULL", v)?
+            } else {
+                write!(self.current, "{}", v)?
+            },
+
+
             ExprType::Name(n) => write!(self.current, "{}", n)?,
             ExprType::Unary(k, v) => {
                 let s = match k {

--- a/repc/arocc/src/main.rs
+++ b/repc/arocc/src/main.rs
@@ -12,7 +12,8 @@ use cly_impl::ast::{Declaration, DeclarationType, TypeVariant};
 // use cly_impl::converter::ConversionResult;
 mod c;
 // use itertools::Itertools;
-use repc_impl::target::{system_compiler, Compiler, Target, TARGETS, TARGET_MAP};
+use lazy_static::lazy_static;
+use repc_impl::target::{system_compiler, Compiler, Target, TARGETS};
 use repc_impl::util::align_to;
 use repc_tests::read_input_config;
 // mod dwarf;
@@ -41,6 +42,229 @@ const ENGLISH: [&str; 20] = [
     "EIGHTEEN",
     "NINETEEN",
 ];
+lazy_static! {
+    static ref REPR_RUST: HashMap<Target, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(Target::Aarch64AppleMacosx, "aarch64-apple-darwin");
+        map.insert(Target::Aarch64Fuchsia, "aarch64-fuchsia");
+        map.insert(Target::Aarch64LinuxAndroid, "aarch64-linux-android");
+        map.insert(Target::Aarch64PcWindowsMsvc, "aarch64-pc-windows-msvc");
+        map.insert(Target::Aarch64UnknownFreebsd, "aarch64-unknown-freebsd");
+        map.insert(Target::Aarch64UnknownHermit, "aarch64-unknown-hermit");
+        map.insert(Target::Aarch64UnknownLinuxGnu, "aarch64-unknown-linux-gnu");
+        map.insert(
+            Target::Aarch64UnknownLinuxMusl,
+            "aarch64-unknown-linux-musl",
+        );
+        map.insert(Target::Aarch64UnknownNetbsd, "aarch64-unknown-netbsd");
+        map.insert(Target::Aarch64UnknownNone, "aarch64-unknown-none");
+        map.insert(Target::Aarch64UnknownOpenbsd, "aarch64-unknown-openbsd");
+        map.insert(Target::Aarch64UnknownRedox, "aarch64-unknown-redox");
+        map.insert(Target::Arm64AppleIos, "aarch64-apple-ios");
+        map.insert(Target::Arm64AppleIosMacabi, "aarch64-apple-ios-macabi");
+        map.insert(Target::Arm64AppleTvos, "aarch64-apple-tvos");
+        map.insert(Target::ArmLinuxAndroideabi, "arm-linux-androideabi");
+        map.insert(Target::ArmUnknownLinuxGnueabi, "arm-unknown-linux-gnueabi");
+        map.insert(
+            Target::ArmUnknownLinuxGnueabihf,
+            "arm-unknown-linux-gnueabihf",
+        );
+        map.insert(Target::Armebv7rUnknownNoneEabi, "armebv7r-none-eabi");
+        map.insert(Target::Armebv7rUnknownNoneEabihf, "armebv7r-none-eabihf");
+        map.insert(
+            Target::Armv4tUnknownLinuxGnueabi,
+            "armv4t-unknown-linux-gnueabi",
+        );
+        map.insert(
+            Target::Armv5teUnknownLinuxGnueabi,
+            "armv5te-unknown-linux-gnueabi",
+        );
+        map.insert(
+            Target::Armv5teUnknownLinuxUclibcgnueabi,
+            "armv5te-unknown-linux-uclibceabi",
+        );
+        map.insert(
+            Target::Armv6UnknownFreebsdGnueabihf,
+            "armv6-unknown-freebsd",
+        );
+        map.insert(
+            Target::Armv6UnknownNetbsdelfEabihf,
+            "armv6-unknown-netbsd-eabihf",
+        );
+        map.insert(Target::Armv7AppleIos, "armv7-apple-ios");
+        map.insert(Target::Armv7NoneLinuxAndroid, "armv7-linux-androideabi");
+        map.insert(
+            Target::Armv7UnknownFreebsdGnueabihf,
+            "armv7-unknown-freebsd",
+        );
+        map.insert(
+            Target::Armv7UnknownLinuxGnueabi,
+            "armv7-unknown-linux-gnueabi",
+        );
+        map.insert(
+            Target::Armv7UnknownLinuxGnueabihf,
+            "armv7-unknown-linux-gnueabihf",
+        );
+        map.insert(
+            Target::Armv7UnknownNetbsdelfEabihf,
+            "armv7-unknown-netbsd-eabihf",
+        );
+        map.insert(Target::Armv7aNoneEabi, "armv7a-none-eabi");
+        map.insert(Target::Armv7aNoneEabihf, "armv7a-none-eabihf");
+        map.insert(Target::Armv7rUnknownNoneEabi, "armv7r-none-eabi");
+        map.insert(Target::Armv7rUnknownNoneEabihf, "armv7r-none-eabihf");
+        map.insert(Target::Armv7sAppleIos, "armv7s-apple-ios");
+        map.insert(Target::AvrUnknownUnknown, "avr-unknown-gnu-atmega328");
+        map.insert(
+            Target::HexagonUnknownLinuxMusl,
+            "hexagon-unknown-linux-musl",
+        );
+        map.insert(Target::I386AppleIos, "i386-apple-ios");
+        map.insert(Target::I586PcWindowsMsvc, "i586-pc-windows-msvc");
+        map.insert(Target::I586UnknownLinuxGnu, "i586-unknown-linux-gnu");
+        map.insert(Target::I586UnknownLinuxMusl, "i586-unknown-linux-musl");
+        map.insert(Target::I686AppleMacosx, "i686-apple-darwin");
+        map.insert(Target::I686LinuxAndroid, "i686-linux-android");
+        map.insert(Target::I686PcWindowsGnu, "i686-pc-windows-gnu");
+        map.insert(Target::I686PcWindowsMsvc, "i686-pc-windows-msvc");
+        map.insert(Target::I686UnknownFreebsd, "i686-unknown-freebsd");
+        map.insert(Target::I686UnknownHaiku, "i686-unknown-haiku");
+        map.insert(Target::I686UnknownLinuxGnu, "i686-unknown-linux-gnu");
+        map.insert(Target::I686UnknownLinuxGnu, "i686-wrs-vxworks");
+        map.insert(Target::I686UnknownLinuxMusl, "i686-unknown-linux-musl");
+        map.insert(Target::I686UnknownNetbsdelf, "i686-unknown-netbsd");
+        map.insert(Target::I686UnknownOpenbsd, "i686-unknown-openbsd");
+        map.insert(Target::I686UnknownWindows, "i686-unknown-uefi");
+        map.insert(
+            Target::Mips64UnknownLinuxGnuabi64,
+            "mips64-unknown-linux-gnuabi64",
+        );
+        map.insert(
+            Target::Mips64UnknownLinuxMusl,
+            "mips64-unknown-linux-muslabi64",
+        );
+        map.insert(
+            Target::Mips64elUnknownLinuxGnuabi64,
+            "mips64el-unknown-linux-gnuabi64",
+        );
+        map.insert(
+            Target::Mips64elUnknownLinuxMusl,
+            "mips64el-unknown-linux-muslabi64",
+        );
+        map.insert(Target::MipsUnknownLinuxGnu, "mips-unknown-linux-gnu");
+        map.insert(Target::MipsUnknownLinuxMusl, "mips-unknown-linux-musl");
+        map.insert(Target::MipsUnknownLinuxUclibc, "mips-unknown-linux-uclibc");
+        map.insert(Target::MipselSonyPsp, "mipsel-sony-psp");
+        map.insert(Target::MipselUnknownLinuxGnu, "mipsel-unknown-linux-gnu");
+        map.insert(Target::MipselUnknownLinuxMusl, "mipsel-unknown-linux-musl");
+        map.insert(
+            Target::MipselUnknownLinuxUclibc,
+            "mipsel-unknown-linux-uclibc",
+        );
+        map.insert(Target::MipselUnknownNone, "mipsel-unknown-none");
+        map.insert(
+            Target::Mipsisa32r6UnknownLinuxGnu,
+            "mipsisa32r6-unknown-linux-gnu",
+        );
+        map.insert(
+            Target::Mipsisa32r6elUnknownLinuxGnu,
+            "mipsisa32r6el-unknown-linux-gnu",
+        );
+        map.insert(
+            Target::Mipsisa64r6UnknownLinuxGnuabi64,
+            "mipsisa64r6-unknown-linux-gnuabi64",
+        );
+        map.insert(
+            Target::Mipsisa64r6elUnknownLinuxGnuabi64,
+            "mipsisa64r6el-unknown-linux-gnuabi64",
+        );
+        map.insert(Target::Msp430NoneElf, "msp430-none-elf");
+        map.insert(Target::Powerpc64UnknownFreebsd, "powerpc64-unknown-freebsd");
+        map.insert(
+            Target::Powerpc64UnknownLinuxGnu,
+            "powerpc64-unknown-linux-gnu",
+        );
+        map.insert(
+            Target::Powerpc64UnknownLinuxMusl,
+            "powerpc64-unknown-linux-musl",
+        );
+        map.insert(
+            Target::Powerpc64leUnknownLinuxGnu,
+            "powerpc64le-unknown-linux-gnu",
+        );
+        map.insert(
+            Target::Powerpc64leUnknownLinuxMusl,
+            "powerpc64le-unknown-linux-musl",
+        );
+        map.insert(Target::PowerpcUnknownLinuxGnu, "powerpc-unknown-linux-gnu");
+        map.insert(
+            Target::PowerpcUnknownLinuxGnuspe,
+            "powerpc-unknown-linux-gnuspe",
+        );
+        map.insert(
+            Target::PowerpcUnknownLinuxMusl,
+            "powerpc-unknown-linux-musl",
+        );
+        map.insert(Target::PowerpcUnknownNetbsd, "powerpc-unknown-netbsd");
+        map.insert(Target::Riscv32, "riscv32i-unknown-none-elf");
+        map.insert(
+            Target::Riscv32UnknownLinuxGnu,
+            "riscv32gc-unknown-linux-gnu",
+        );
+        map.insert(Target::Riscv64, "riscv64gc-unknown-none-elf");
+        map.insert(
+            Target::Riscv64UnknownLinuxGnu,
+            "riscv64gc-unknown-linux-gnu",
+        );
+        map.insert(Target::S390xUnknownLinuxGnu, "s390x-unknown-linux-gnu");
+        map.insert(Target::Sparc64UnknownLinuxGnu, "sparc64-unknown-linux-gnu");
+        map.insert(Target::Sparc64UnknownNetbsd, "sparc64-unknown-netbsd");
+        map.insert(Target::Sparc64UnknownOpenbsd, "sparc64-unknown-openbsd");
+        map.insert(Target::SparcUnknownLinuxGnu, "sparc-unknown-linux-gnu");
+        map.insert(Target::Sparcv9SunSolaris, "sparcv9-sun-solaris");
+        map.insert(Target::Thumbv4tNoneEabi, "thumbv4t-none-eabi");
+        map.insert(Target::Thumbv6mNoneEabi, "thumbv6m-none-eabi");
+        map.insert(Target::Thumbv7aPcWindowsMsvc, "thumbv7a-pc-windows-msvc");
+        map.insert(Target::Thumbv7emNoneEabi, "thumbv7em-none-eabi");
+        map.insert(Target::Thumbv7emNoneEabihf, "thumbv7em-none-eabihf");
+        map.insert(Target::Thumbv7mNoneEabi, "thumbv7m-none-eabi");
+        map.insert(Target::Thumbv8mBaseNoneEabi, "thumbv8m.base-none-eabi");
+        map.insert(Target::Thumbv8mMainNoneEabihf, "thumbv8m.main-none-eabihf");
+        map.insert(Target::Wasm32UnknownEmscripten, "wasm32-unknown-emscripten");
+        map.insert(Target::Wasm32UnknownUnknown, "wasm32-unknown-unknown");
+        map.insert(Target::Wasm32Wasi, "wasm32-wasi");
+        map.insert(Target::X86_64AppleIos, "x86_64-apple-ios");
+        map.insert(Target::X86_64AppleIosMacabi, "x86_64-apple-ios-macabi");
+        map.insert(Target::X86_64AppleMacosx, "x86_64-apple-darwin");
+        map.insert(Target::X86_64AppleTvos, "x86_64-apple-tvos");
+        map.insert(Target::X86_64Elf, "x86_64-linux-kernel");
+        map.insert(Target::X86_64Fuchsia, "x86_64-fuchsia");
+        map.insert(Target::X86_64LinuxAndroid, "x86_64-linux-android");
+        map.insert(Target::X86_64PcSolaris, "x86_64-pc-solaris");
+        map.insert(Target::X86_64PcWindowsGnu, "x86_64-pc-windows-gnu");
+        map.insert(Target::X86_64PcWindowsMsvc, "x86_64-pc-windows-msvc");
+        map.insert(Target::X86_64RumprunNetbsd, "x86_64-rumprun-netbsd");
+        map.insert(Target::X86_64UnknownDragonfly, "x86_64-unknown-dragonfly");
+        map.insert(Target::X86_64UnknownFreebsd, "x86_64-unknown-freebsd");
+        map.insert(Target::X86_64UnknownHaiku, "x86_64-unknown-haiku");
+        map.insert(Target::X86_64UnknownHermit, "x86_64-unknown-hermit");
+        map.insert(
+            Target::X86_64UnknownL4reUclibc,
+            "x86_64-unknown-l4re-uclibc",
+        );
+        map.insert(Target::X86_64UnknownLinuxGnu, "x86_64-unknown-linux-gnu");
+        map.insert(
+            Target::X86_64UnknownLinuxGnux32,
+            "x86_64-unknown-linux-gnux32",
+        );
+        map.insert(Target::X86_64UnknownLinuxMusl, "x86_64-unknown-linux-musl");
+        map.insert(Target::X86_64UnknownNetbsd, "x86_64-unknown-netbsd");
+        map.insert(Target::X86_64UnknownOpenbsd, "x86_64-unknown-openbsd");
+        map.insert(Target::X86_64UnknownRedox, "x86_64-unknown-redox");
+        map.insert(Target::X86_64UnknownWindows, "x86_64-unknown-uefi");
+        map
+    };
+}
 
 fn main() {
     if let Err(e) = main_() {
@@ -66,17 +290,27 @@ fn main_() -> std::io::Result<()> {
             rust_zig_map.insert(x.0.to_owned(), x.1.to_owned());
         });
 
-        // reprc targets map to mutiple rust targets. So insert by hand.
-        for (rust, reprc) in TARGET_MAP {
-            //.iter().map(|t| (t.1, t.0)).collect();
-            match rust_zig_map.get(rust.to_owned()) {
-                Some(z) => {
-                    // only insert the first one
-                    if !reprc_zig_map.contains_key(reprc) {
-                        reprc_zig_map.insert(*reprc, z.clone());
-                    }
+        for reprc in TARGETS {
+            assert!(!reprc_zig_map.contains_key(reprc));
+            // the reprc targets are more accurate,
+            // so see if a mapping exits and use that.
+            // except for windows targets. Use the rustc ones.
+            let repr = rust_zig_map.get(reprc.name());
+            let rust = match REPR_RUST.get(reprc) {
+                Some(r) => rust_zig_map.get(*r),
+                None => None,
+            };
+            match (repr, rust) {
+                (Some(r), None) => _ = reprc_zig_map.insert(*reprc, r.clone()),
+                (None, Some(u)) => _ = reprc_zig_map.insert(*reprc, u.clone()),
+                (Some(r), Some(u)) => {
+                    if r.contains("windows") || r.contains("uefi") {
+                        reprc_zig_map.insert(*reprc, u.clone());
+                    } else {
+                        reprc_zig_map.insert(*reprc, r.clone());
+                    };
                 }
-                None => println!("no mapping for {:?} | {}", reprc, rust),
+                (None, None) => println!("no map for {:?}", reprc),
             }
         }
     }
@@ -224,7 +458,6 @@ fn main_() -> std::io::Result<()> {
                             d.name, align
                         )
                         .unwrap();
-                        writeln!(out_str, "#ifdef EXTRA_TESTS").unwrap();
                         let d_size = if size > 0 {
                             align_to(size, align).unwrap()
                         } else {
@@ -232,59 +465,58 @@ fn main_() -> std::io::Result<()> {
                         };
                         writeln!(
                             out_str,
-                            "_Static_assert(sizeof(struct {}_alignment) == {}, \"\");",
+                            "_Static_assert(sizeof(struct {}_extra_alignment) == {}, \"\");",
                             d.name,
                             d_size + align
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(_Alignof(struct {}_alignment) == {}, \"\");",
+                            "_Static_assert(_Alignof(struct {}_extra_alignment) == {}, \"\");",
                             d.name, align
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(sizeof(struct {}_packed) == {}, \"\");",
+                            "_Static_assert(sizeof(struct {}_extra_packed) == {}, \"\");",
                             d.name, size
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(_Alignof(struct {}_packed) == {}, \"\");",
+                            "_Static_assert(_Alignof(struct {}_extra_packed) == {}, \"\");",
                             d.name, 1
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(sizeof(struct {}_required_alignment) == {}, \"\");",
+                            "_Static_assert(sizeof(struct {}_extra_required_alignment) == {}, \"\");",
                             d.name,
                             size + 1
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(_Alignof(struct {}_required_alignment) == {}, \"\");",
+                            "_Static_assert(_Alignof(struct {}_extra_required_alignment) == {}, \"\");",
                             d.name, 1
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(sizeof(struct {}_size) == {}, \"\");",
+                            "_Static_assert(sizeof(struct {}_extra_size) == {}, \"\");",
                             d.name,
                             size + 2
                         )
                         .unwrap();
                         writeln!(
                             out_str,
-                            "_Static_assert(_Alignof(struct {}_size) == {}, \"\");",
+                            "_Static_assert(_Alignof(struct {}_extra_size) == {}, \"\");",
                             d.name, 1
                         )
                         .unwrap();
-                        writeln!(out_str, "#endif").unwrap();
                         if let TypeVariant::Record(r) = t.variant {
                             if r.fields.len() > 1 {
-                                writeln!(out_str, "#ifdef CHECK_OFFSETS").unwrap();
+                                writeln!(out_str, "#ifndef SKIP_OFFSETS").unwrap();
                                 // the first one is always zero. Can skip
                                 for f in r.fields.into_iter().skip(1) {
                                     if let (Some(name), Some(layout)) = (f.name, f.layout) {

--- a/repc/arocc/src/main.rs
+++ b/repc/arocc/src/main.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
+use std::iter::FromIterator;
 // use std::fs::File;
 // use std::mem;
 // use std::path::PathBuf;
@@ -9,13 +10,37 @@ use std::process;
 
 use cly_impl::ast::{Declaration, DeclarationType, TypeVariant};
 // use cly_impl::converter::ConversionResult;
-use repc_impl::target::{system_compiler, Compiler, Target, TARGETS};
-use repc_tests::read_input_config;
-
-#[path = "../../test-generator/src/c.rs"]
 mod c;
+// use itertools::Itertools;
+use repc_impl::target::{system_compiler, Compiler, Target, TARGETS, TARGET_MAP};
+use repc_impl::util::align_to;
+use repc_tests::read_input_config;
 // mod dwarf;
 // mod pdb;
+
+// numer to english word
+const ENGLISH: [&str; 20] = [
+    "ZERO",
+    "ONE",
+    "TWO",
+    "THREE",
+    "FOUR",
+    "FIVE",
+    "SIX",
+    "SEVEN",
+    "EIGHT",
+    "NINE",
+    "TEN",
+    "ELEVEN",
+    "TWELVE",
+    "THIRTEEN",
+    "FOURTEEN",
+    "FIFTEEN",
+    "SIXTEEN",
+    "SEVENTEEN",
+    "EIGHTEEN",
+    "NINETEEN",
+];
 
 fn main() {
     if let Err(e) = main_() {
@@ -28,17 +53,30 @@ fn main() {
 /// it's only intended to be run once, to generate the test files
 /// for arocc. Don't judge me.
 fn main_() -> std::io::Result<()> {
-    // let userconfig: GlobalConfig = toml::from_str(&std::fs::read_to_string("config.toml")?)?;
+    let mut reprc_zig_map: HashMap<Target, String> = HashMap::new();
+    {
+        let mut rust_zig_map: HashMap<String, String> = HashMap::new();
 
-    // let skip: HashSet<&str> = HashSet::from([
-    //     // typdef align
-    //     "0007", "0008", "0010", "0011", "0014", "0028", "0029", "0044", "0045", "0046", "0058",
-    //     "0066", "0070", "0080", "0081", "0082", "0084", "0085", "0086",
-    //     // // enum attr packed issue.
-    //     "0055", "0060", "0062", // assert
-    //     "0050", // clang fails
-    //     "0083",
-    // ]);
+        let m_file = std::fs::read_to_string("mapping.text")?;
+        m_file.lines().for_each(|l| {
+            let x = l.split_once(':').unwrap();
+            rust_zig_map.insert(x.0.to_owned(), x.1.to_owned());
+        });
+
+        // reprc targets map to mutiple rust targets. So insert by hand.
+        for (rust, reprc) in TARGET_MAP {
+            //.iter().map(|t| (t.1, t.0)).collect();
+            match rust_zig_map.get(rust.to_owned()) {
+                Some(z) => {
+                    // only insert the first one
+                    if !reprc_zig_map.contains_key(reprc) {
+                        reprc_zig_map.insert(*reprc, z.clone());
+                    }
+                }
+                None => println!("no mapping for {:?} | {}", reprc, rust),
+            }
+        }
+    }
 
     let mut dirs = vec![];
     for dir in std::fs::read_dir("testfiles").expect("Can't open testfiles dir") {
@@ -48,159 +86,219 @@ fn main_() -> std::io::Result<()> {
         }
     }
     dirs.sort();
-    dirs.iter().for_each(|dir| {
+    for dir in dirs.iter() {
         let config = read_input_config(dir).unwrap();
         let input_path = dir.join("input.txt");
-        let input = std::fs::read_to_string(&input_path).expect("akjhsd");
-        // let hash = {
-        //     let mut hash = DefaultHasher::new();
-        //     input.hash(&mut hash);
-        //     config.0.hash(&mut hash);
-        //     hash.finish()
-        // };
+        let input = std::fs::read_to_string(&input_path).expect("");
         let declarations = cly_impl::parse(&input).unwrap();
+        // let zig_targets:HashSet<&str> = HashSet::new();
 
-        let targets:Vec<_> = TARGETS.iter().filter(|t| { config.1.test_target(**t) }).collect();
+        let targets: Vec<_> = TARGETS
+            .iter()
+            .filter(|t| config.1.test_target(**t))
+            .collect();
         // if targets.contains(&&Target::X86_64UnknownLinuxGnu) {
-            let mut comps: HashSet<_> = targets.iter().map(|t| { system_compiler(**t) }).collect();
+        let mut comps: HashSet<_> = targets.iter().map(|t| system_compiler(**t)).collect();
 
-            if comps.contains(&Compiler::Clang) && comps.contains(&Compiler::Gcc) {
-                comps.remove(&Compiler::Gcc);
-            }
+        if comps.contains(&Compiler::Clang) && comps.contains(&Compiler::Gcc) {
+            comps.remove(&Compiler::Gcc);
+        }
 
-            let dir_name = dir.file_name().unwrap().to_str().unwrap();
-            let f_name = format!("{}_test.c", dir_name);
-            // println!("{}", f_name);
-            let mut out_str = "// SPDX-License-Identifier: GPL-3.0-or-later\n\n\
-            // This test file is auto-generated. do not edit.\n\
-            // This file is a derivative work from the test files found\
-            // in this repo : https://github.com/mahkoh/repr-c\n\
-            // and is under the same licence as the original work.\n\n".to_string();
+        let dir_name = dir.file_name().unwrap().to_str().unwrap();
+        let f_name = format!("{}_test.c", dir_name);
+        let mut out_str = "// SPDX-License-Identifier: GPL-3.0-or-later\n\n\
+        // This test file is auto-generated. do not edit.\n\
+        // This file is a derivative work from the test files found\
+        // in this repo : https://github.com/mahkoh/repr-c\n\
+        // and is under the same licence as the original work.\n\n"
+            .to_string();
 
-            let c_code = if comps.contains(&Compiler::Clang) {
-                let (code, _ids) = c::generate(&declarations, Compiler::Clang).unwrap();
-                Some(code)
-            } else {
-                None
+        let c_code = if comps.contains(&Compiler::Clang) {
+            let (code, _ids) = c::generate(&declarations, Compiler::Clang).unwrap();
+            Some(code)
+        } else {
+            None
+        };
+
+        let m_code = if comps.contains(&Compiler::Msvc) {
+            let (code, _ids) = c::generate(&declarations, Compiler::Msvc).unwrap();
+            Some(code)
+        } else {
+            None
+        };
+
+        match (c_code, m_code) {
+            (Some(c), None) => writeln!(out_str, "{}", c).unwrap(),
+            (None, Some(m)) => writeln!(out_str, "#ifdef MSVC\n{}\n#endif\n", m).unwrap(),
+            (Some(c), Some(m)) => merge_two(c, m, &mut out_str),
+            (None, None) => unreachable!(),
+        };
+
+        #[derive(Debug)]
+        struct TargetAst {
+            targets: Vec<Target>,
+            decls: Vec<Declaration>,
+        }
+
+        let mut uniq: Vec<TargetAst> = Vec::new();
+
+        targets.iter().for_each(|target| {
+            // let target = &&Target::X86_64UnknownLinuxGnu;
+            let tname = target.name();
+            let exp_file = dir.join("output").join(format!("{}.expected.txt", tname));
+            let exp_str = std::fs::read_to_string(&exp_file).expect("can't open output file");
+            let decls = cly_impl::parse(&exp_str).expect("can't open output file");
+            // let ast = cly_impl::extract_layouts( &exp_str, &decls).expect("can't parse output file");
+
+            let idx = uniq.iter().position(|u| u.decls == decls);
+            match idx {
+                None => {
+                    uniq.push(TargetAst {
+                        targets: vec![**target],
+                        decls,
+                    });
+                }
+                Some(i) => {
+                    uniq[i].targets.push(**target);
+                }
             };
+        });
 
-            let m_code = if comps.contains(&Compiler::Msvc) {
-                let (code, _ids) = c::generate(&declarations, Compiler::Msvc).unwrap();
-                Some(code)
-            } else {
-                None
-            };
-
-            match (c_code, m_code) {
-                (Some(c), None) => writeln!(out_str, "{}", c).unwrap(),
-                (None, Some(m)) => writeln!(out_str, "#ifdef MSVC\n{}\n#endif\n", m).unwrap(),
-                (Some(c), Some(m)) => merge_two(c, m, &mut out_str),
-                (None, None) => unreachable!()
-            };
-
-            #[derive(Debug)]
-            struct TargetAst {
-                targets: Vec<Target>,
-                decls: Vec<Declaration>,
-            }
-
-            let mut uniq: Vec<TargetAst> = Vec::new();
-
-            targets.iter().for_each( |target| {
-                // let target = &&Target::X86_64UnknownLinuxGnu;
-                let tname = target.name();
-                let exp_file = dir.join("output").join(format!("{}.expected.txt", tname));
-                let exp_str = std::fs::read_to_string(&exp_file).expect("can't open output file");
-                let decls = cly_impl::parse(&exp_str).expect("can't open output file");
-                // let ast = cly_impl::extract_layouts( &exp_str, &decls).expect("can't parse output file");
-
-                let idx = uniq.iter().position(|u| {
-                    u.decls == decls
-                });
-                match idx {
-                    None => {
-                        uniq.push(TargetAst {
-                            targets: vec![**target],
-                            decls,
-                        });
+        let t_sets: Vec<HashSet<_>> = uniq
+            .iter()
+            .map(|a| HashSet::from_iter(a.targets.iter().filter_map(|t| reprc_zig_map.get(t))))
+            .collect();
+        for o in t_sets.iter() {
+            for i in t_sets.iter() {
+                if i != o {
+                    let dup: HashSet<_> = i.intersection(o).collect();
+                    if !dup.is_empty() {
+                        panic!("file {:?} zig targets overlap {:?}\n", dir, dup);
                     }
-                    Some(i) => {
-                        uniq[i].targets.push(**target);
-                    }
-                };
-            });
-                // println!("{:?}",ast);
-
-                // panic!("done");
-                // });
-                let mut first = true;
-                for x in uniq {
-                    if first {
-                        first = false;
-                        write!(out_str, "#if ").unwrap();
+                }
+            }
+        }
+        let mut count = 1;
+        for x in uniq {
+            write!(out_str, "// MAPPING|{}|", ENGLISH[count]).unwrap();
+            x.targets
+                .iter()
+                .filter_map(|t| {
+                    if let Some(z) = reprc_zig_map.get(t) {
+                        Some((z, system_compiler(*t)))
                     } else {
-                        write!(out_str, "#elif ").unwrap();
+                        None
                     }
-                    let t_def = x.targets.iter()
-                        .map(|s| format!("defined({})",s.name().to_string().replace("_","").replace("-","_").replace(".","").to_uppercase()))
-                        .reduce(|a,b| format!("{} || {}", a, b));
-                    let mut line_len=4;
-
-                    for part in t_def.unwrap().split_inclusive("||") {
-                        if line_len > 125 {
-                            writeln!(out_str," \\").unwrap();
-                            line_len = 0;
-                        }
-                        write!(out_str, "{} ", part).unwrap();
-                        line_len += part.len();
-                    }
-                    writeln!(out_str,"").unwrap();
-                    // writeln!(out_str, "{}", t_def.unwrap()).unwrap();
-                    for d in x.decls {
-                        // println!("\n\nname = {}", d.name);
-                        if let DeclarationType::Type(t) = d.ty {
-                            if let Some(type_layout) = t.layout {
-                                let align = type_layout.field_alignment_bits / 8;
-                                let size = type_layout.size_bits / 8;
-                                writeln!(out_str, "_Static_assert(sizeof({}) == {}, \"record {0} wrong sizeof\");", d.name, size).unwrap();
-                                writeln!(out_str, "_Static_assert(_Alignof({}) == {}, \"record {0} wrong alignment\");", d.name, align).unwrap();
-                                writeln!(out_str, "#ifdef EXTRA_TESTS").unwrap();
-                                let d_size = if size > 0 { size.max(align) } else { 0 };
-                                writeln!(out_str, "_Static_assert(sizeof(struct {}_alignment) == {}, \"record {0} wrong sizeof\");", d.name, align+d_size).unwrap();
-                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_alignment) == {}, \"record {0} wrong alignment\");", d.name, align).unwrap();
-                                writeln!(out_str, "_Static_assert(sizeof(struct {}_packed) == {}, \"record {0} wrong sizeof\");", d.name, size).unwrap();
-                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_packed) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
-                                writeln!(out_str, "_Static_assert(sizeof(struct {}_required_alignment) == {}, \"record {0} wrong sizeof\");", d.name, size+1).unwrap();
-                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_required_alignment) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
-                                writeln!(out_str, "_Static_assert(sizeof(struct {}_size) == {}, \"record {0} wrong sizeof\");", d.name, size+2).unwrap();
-                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_size) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
-                                writeln!(out_str, "#endif").unwrap();
-                                if let TypeVariant::Record(r) = t.variant {
-                                    if r.fields.len() > 1 {
-                                        writeln!(out_str, "#ifdef CHECK_OFFSETS").unwrap();
-                                        // the first one is always zero. Can skip
-                                        for f in r.fields.into_iter().skip(1) {
-                                            if let (Some(name), Some(layout)) = (f.name, f.layout) {
-                                                // println!("\n\t\t{} = {}", name, layout.offset_bits);
-                                                writeln!(out_str, "_Static_assert(__builtin_bitoffsetof({0},{1}) == {2}, \"field {0}.{1} wrong bit offset\");", d.name, name, layout.offset_bits).unwrap();
-                                            }
-                                        }
-                                        writeln!(out_str, "#endif").unwrap();
+                })
+                .for_each(|t| write!(out_str, "{}:{:?}|", t.0, t.1).unwrap());
+            write!(out_str, "END\n").unwrap();
+            write!(out_str, "// repr targets ").unwrap();
+            for t in x.targets {
+                write!(out_str, "{:?}|{:?} ", t, reprc_zig_map.get(&t)).unwrap();
+            }
+            writeln!(out_str, "").unwrap();
+            if count == 1 {
+                writeln!(out_str, "#ifdef {}", ENGLISH[count]).unwrap();
+            } else {
+                writeln!(out_str, "#elif defined({})", ENGLISH[count]).unwrap();
+            }
+            count += 1;
+            for d in x.decls {
+                // println!("\n\nname = {}", d.name);
+                if let DeclarationType::Type(t) = d.ty {
+                    if let Some(type_layout) = t.layout {
+                        let align = type_layout.field_alignment_bits / 8;
+                        let size = type_layout.size_bits / 8;
+                        writeln!(
+                            out_str,
+                            "_Static_assert(sizeof({}) == {}, \"\");",
+                            d.name, size
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(_Alignof({}) == {}, \"\");",
+                            d.name, align
+                        )
+                        .unwrap();
+                        writeln!(out_str, "#ifdef EXTRA_TESTS").unwrap();
+                        let d_size = if size > 0 {
+                            align_to(size, align).unwrap()
+                        } else {
+                            0
+                        };
+                        writeln!(
+                            out_str,
+                            "_Static_assert(sizeof(struct {}_alignment) == {}, \"\");",
+                            d.name,
+                            d_size + align
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(_Alignof(struct {}_alignment) == {}, \"\");",
+                            d.name, align
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(sizeof(struct {}_packed) == {}, \"\");",
+                            d.name, size
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(_Alignof(struct {}_packed) == {}, \"\");",
+                            d.name, 1
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(sizeof(struct {}_required_alignment) == {}, \"\");",
+                            d.name,
+                            size + 1
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(_Alignof(struct {}_required_alignment) == {}, \"\");",
+                            d.name, 1
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(sizeof(struct {}_size) == {}, \"\");",
+                            d.name,
+                            size + 2
+                        )
+                        .unwrap();
+                        writeln!(
+                            out_str,
+                            "_Static_assert(_Alignof(struct {}_size) == {}, \"\");",
+                            d.name, 1
+                        )
+                        .unwrap();
+                        writeln!(out_str, "#endif").unwrap();
+                        if let TypeVariant::Record(r) = t.variant {
+                            if r.fields.len() > 1 {
+                                writeln!(out_str, "#ifdef CHECK_OFFSETS").unwrap();
+                                // the first one is always zero. Can skip
+                                for f in r.fields.into_iter().skip(1) {
+                                    if let (Some(name), Some(layout)) = (f.name, f.layout) {
+                                        // println!("\n\t\t{} = {}", name, layout.offset_bits);
+                                        writeln!(out_str, "_Static_assert(__builtin_bitoffsetof({0},{1}) == {2}, \"\");", d.name, name, layout.offset_bits).unwrap();
                                     }
                                 }
+                                writeln!(out_str, "#endif").unwrap();
                             }
                         }
                     }
-                    // std::fs::write(&f_name, out_str).unwrap();
-                    //
-                    // // panic!("done");
-                    // break;
-                    // println!("{:?}", x.ast.types);
-                    // panic!("done");
                 }
-            writeln!(out_str, "#endif").unwrap();
-            std::fs::write(&f_name, out_str).unwrap();
-        });
+            }
+        }
+        writeln!(out_str, "#endif").unwrap();
+        std::fs::write(&f_name, out_str).unwrap();
+    }
     Ok(())
 }
 

--- a/repc/arocc/src/main.rs
+++ b/repc/arocc/src/main.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-use anyhow::{anyhow, bail, Context, Result};
-use cly_impl::ast::Declaration;
-use rayon::iter::IntoParallelRefIterator;
-use rayon::iter::ParallelIterator;
-use repc_impl::target::{system_compiler, Compiler, Target, TARGETS};
-use repc_tests::{read_input_config, GlobalConfig, InputConfig};
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
-use std::fs::{File, OpenOptions};
-use std::hash::{Hash, Hasher};
-use std::io::{ErrorKind, Write};
-use std::path::Path;
-use std::process;
-use std::process::Command;
 
-#[path="../../test-generator/src/c.rs"]
+use std::collections::HashSet;
+use std::fmt::Write;
+// use std::fs::File;
+// use std::mem;
+// use std::path::PathBuf;
+use std::process;
+
+use cly_impl::ast::{Declaration, DeclarationType, TypeVariant};
+// use cly_impl::converter::ConversionResult;
+use repc_impl::target::{system_compiler, Compiler, Target, TARGETS};
+use repc_tests::read_input_config;
+
+#[path = "../../test-generator/src/c.rs"]
 mod c;
 // mod dwarf;
 // mod pdb;
@@ -29,20 +27,29 @@ fn main() {
 /// this is ugly ugly ugly code.
 /// it's only intended to be run once, to generate the test files
 /// for arocc. Don't judge me.
-fn main_() -> Result<()> {
+fn main_() -> std::io::Result<()> {
     // let userconfig: GlobalConfig = toml::from_str(&std::fs::read_to_string("config.toml")?)?;
+
+    // let skip: HashSet<&str> = HashSet::from([
+    //     // typdef align
+    //     "0007", "0008", "0010", "0011", "0014", "0028", "0029", "0044", "0045", "0046", "0058",
+    //     "0066", "0070", "0080", "0081", "0082", "0084", "0085", "0086",
+    //     // // enum attr packed issue.
+    //     "0055", "0060", "0062", // assert
+    //     "0050", // clang fails
+    //     "0083",
+    // ]);
 
     let mut dirs = vec![];
     for dir in std::fs::read_dir("testfiles").expect("Can't open testfiles dir") {
         let dir = dir?;
-        if dir.file_type()?.is_dir() { //&& userconfig.test_test(dir.file_name().to_str().unwrap()) {
+        if dir.file_type()?.is_dir() {
             dirs.push(dir.path());
         }
     }
     dirs.sort();
     dirs.iter().for_each(|dir| {
-        let config = read_input_config(dir)
-            .with_context(|| anyhow!("cannot read config in {}", dir.display())).expect("aksljdh");
+        let config = read_input_config(dir).unwrap();
         let input_path = dir.join("input.txt");
         let input = std::fs::read_to_string(&input_path).expect("akjhsd");
         // let hash = {
@@ -51,105 +58,185 @@ fn main_() -> Result<()> {
         //     config.0.hash(&mut hash);
         //     hash.finish()
         // };
-        let declarations = cly_impl::parse(&input)
-            .with_context(|| anyhow!("Parsing of {} failed", input_path.display())).expect("failed to parse input file");
+        let declarations = cly_impl::parse(&input).unwrap();
 
         let targets:Vec<_> = TARGETS.iter().filter(|t| { config.1.test_target(**t) }).collect();
-        let mut comps:HashSet<_> = targets.iter().map(|t|{system_compiler(**t)}).collect();
+        // if targets.contains(&&Target::X86_64UnknownLinuxGnu) {
+            let mut comps: HashSet<_> = targets.iter().map(|t| { system_compiler(**t) }).collect();
 
-        if comps.contains( &Compiler::Clang ) && comps.contains( &Compiler::Gcc ) {
-            comps.remove(&Compiler::Gcc);
-        }
+            if comps.contains(&Compiler::Clang) && comps.contains(&Compiler::Gcc) {
+                comps.remove(&Compiler::Gcc);
+            }
 
-        let dir_name = dir.file_name().unwrap().to_str().unwrap();
-        let f_name = format!("{}_test.c",dir_name);
-        println!("{}",f_name);
+            let dir_name = dir.file_name().unwrap().to_str().unwrap();
+            let f_name = format!("{}_test.c", dir_name);
+            // println!("{}", f_name);
+            let mut out_str = "// SPDX-License-Identifier: GPL-3.0-or-later\n\n\
+            // This test file is auto-generated. do not edit.\n\
+            // This file is a derivative work from the test files found\
+            // in this repo : https://github.com/mahkoh/repr-c\n\
+            // and is under the same licence as the original work.\n\n".to_string();
 
-        let c_code = if comps.contains( &Compiler::Clang ) {
-            let (code, ids) = c::generate(&declarations,Compiler::Clang).unwrap();
-            Some(code)
-        } else {
-            None
-        };
+            let c_code = if comps.contains(&Compiler::Clang) {
+                let (code, _ids) = c::generate(&declarations, Compiler::Clang).unwrap();
+                Some(code)
+            } else {
+                None
+            };
 
-        let m_code = if comps.contains( &Compiler::Msvc ) {
-            let (code, ids) = c::generate(&declarations,Compiler::Msvc).unwrap();
-            Some(code)
-        } else {
-            None
-        };
+            let m_code = if comps.contains(&Compiler::Msvc) {
+                let (code, _ids) = c::generate(&declarations, Compiler::Msvc).unwrap();
+                Some(code)
+            } else {
+                None
+            };
 
-        match (c_code, m_code) {
-            (Some(c),None) => std::fs::write(f_name, c).expect("die die die"),
-            (None,Some(m)) => std::fs::write(f_name, m).expect("die die die"),
-            (Some(c), Some(m)) => merge_two(c,m,f_name),
-            (None, None) => unreachable!()
-        };
+            match (c_code, m_code) {
+                (Some(c), None) => writeln!(out_str, "{}", c).unwrap(),
+                (None, Some(m)) => writeln!(out_str, "#ifdef MSVC\n{}\n#endif\n", m).unwrap(),
+                (Some(c), Some(m)) => merge_two(c, m, &mut out_str),
+                (None, None) => unreachable!()
+            };
 
+            #[derive(Debug)]
+            struct TargetAst {
+                targets: Vec<Target>,
+                decls: Vec<Declaration>,
+            }
 
+            let mut uniq: Vec<TargetAst> = Vec::new();
 
+            targets.iter().for_each( |target| {
+                // let target = &&Target::X86_64UnknownLinuxGnu;
+                let tname = target.name();
+                let exp_file = dir.join("output").join(format!("{}.expected.txt", tname));
+                let exp_str = std::fs::read_to_string(&exp_file).expect("can't open output file");
+                let decls = cly_impl::parse(&exp_str).expect("can't open output file");
+                // let ast = cly_impl::extract_layouts( &exp_str, &decls).expect("can't parse output file");
 
+                let idx = uniq.iter().position(|u| {
+                    u.decls == decls
+                });
+                match idx {
+                    None => {
+                        uniq.push(TargetAst {
+                            targets: vec![**target],
+                            decls,
+                        });
+                    }
+                    Some(i) => {
+                        uniq[i].targets.push(**target);
+                    }
+                };
+            });
+                // println!("{:?}",ast);
 
-    });
+                // panic!("done");
+                // });
+                let mut first = true;
+                for x in uniq {
+                    if first {
+                        first = false;
+                        write!(out_str, "#if ").unwrap();
+                    } else {
+                        write!(out_str, "#elif ").unwrap();
+                    }
+                    let t_def = x.targets.iter()
+                        .map(|s| format!("defined({})",s.name().to_string().replace("_","").replace("-","_").replace(".","").to_uppercase()))
+                        .reduce(|a,b| format!("{} || {}", a, b));
+                    let mut line_len=4;
+
+                    for part in t_def.unwrap().split_inclusive("||") {
+                        if line_len > 125 {
+                            writeln!(out_str," \\").unwrap();
+                            line_len = 0;
+                        }
+                        write!(out_str, "{} ", part).unwrap();
+                        line_len += part.len();
+                    }
+                    writeln!(out_str,"").unwrap();
+                    // writeln!(out_str, "{}", t_def.unwrap()).unwrap();
+                    for d in x.decls {
+                        // println!("\n\nname = {}", d.name);
+                        if let DeclarationType::Type(t) = d.ty {
+                            if let Some(type_layout) = t.layout {
+                                let align = type_layout.field_alignment_bits / 8;
+                                let size = type_layout.size_bits / 8;
+                                writeln!(out_str, "_Static_assert(sizeof({}) == {}, \"record {0} wrong sizeof\");", d.name, size).unwrap();
+                                writeln!(out_str, "_Static_assert(_Alignof({}) == {}, \"record {0} wrong alignment\");", d.name, align).unwrap();
+                                writeln!(out_str, "#ifdef EXTRA_TESTS").unwrap();
+                                let d_size = if size > 0 { size.max(align) } else { 0 };
+                                writeln!(out_str, "_Static_assert(sizeof(struct {}_alignment) == {}, \"record {0} wrong sizeof\");", d.name, align+d_size).unwrap();
+                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_alignment) == {}, \"record {0} wrong alignment\");", d.name, align).unwrap();
+                                writeln!(out_str, "_Static_assert(sizeof(struct {}_packed) == {}, \"record {0} wrong sizeof\");", d.name, size).unwrap();
+                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_packed) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
+                                writeln!(out_str, "_Static_assert(sizeof(struct {}_required_alignment) == {}, \"record {0} wrong sizeof\");", d.name, size+1).unwrap();
+                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_required_alignment) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
+                                writeln!(out_str, "_Static_assert(sizeof(struct {}_size) == {}, \"record {0} wrong sizeof\");", d.name, size+2).unwrap();
+                                writeln!(out_str, "_Static_assert(_Alignof(struct {}_size) == {}, \"record {0} wrong alignment\");", d.name,1 ).unwrap();
+                                writeln!(out_str, "#endif").unwrap();
+                                if let TypeVariant::Record(r) = t.variant {
+                                    if r.fields.len() > 1 {
+                                        writeln!(out_str, "#ifdef CHECK_OFFSETS").unwrap();
+                                        // the first one is always zero. Can skip
+                                        for f in r.fields.into_iter().skip(1) {
+                                            if let (Some(name), Some(layout)) = (f.name, f.layout) {
+                                                // println!("\n\t\t{} = {}", name, layout.offset_bits);
+                                                writeln!(out_str, "_Static_assert(__builtin_bitoffsetof({0},{1}) == {2}, \"field {0}.{1} wrong bit offset\");", d.name, name, layout.offset_bits).unwrap();
+                                            }
+                                        }
+                                        writeln!(out_str, "#endif").unwrap();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // std::fs::write(&f_name, out_str).unwrap();
+                    //
+                    // // panic!("done");
+                    // break;
+                    // println!("{:?}", x.ast.types);
+                    // panic!("done");
+                }
+            writeln!(out_str, "#endif").unwrap();
+            std::fs::write(&f_name, out_str).unwrap();
+        });
     Ok(())
 }
 
-
-fn merge_two(c:String, m:String, f_name:String) {
-    let mut f_out = File::create(f_name).expect("die die die");
+fn merge_two(c: String, m: String, out_str: &mut String) {
     let mut c_idx = 0;
     let mut m_idx = 0;
-    let c_v:Vec<_> = c.lines().map(|s|s.to_string()).collect();
-    let m_v:Vec<_> = m.lines().map(|s|s.to_string()).collect();
+    let c_v: Vec<_> = c.lines().map(|s| s.to_string()).collect();
+    let m_v: Vec<_> = m.lines().map(|s| s.to_string()).collect();
     let mut c_a = 0;
     let mut is_open = false;
     while c_idx < c_v.len() && m_idx < m_v.len() {
         if c_v[c_idx + c_a] == m_v[m_idx] {
             if is_open {
-                writeln!(f_out, "#else" );
-                let cur = c_idx+c_a;
+                writeln!(out_str, "#else").unwrap();
+                let cur = c_idx + c_a;
                 while c_idx < cur {
-                    writeln!(f_out, "{}", c_v[c_idx] );
+                    writeln!(out_str, "{}", &c_v[c_idx]).unwrap();
                     c_idx += 1;
                     // println!("{} {}", c_idx, c_idx+c_a );
                 }
                 // println!("le");
-                writeln!(f_out, "#endif" );
+                writeln!(out_str, "#endif").unwrap();
                 is_open = false;
                 c_a = 0;
             }
-            writeln!(f_out, "{}", c_v[c_idx] );
+            writeln!(out_str, "{}", &c_v[c_idx]).unwrap();
             c_idx += 1;
             m_idx += 1;
         } else {
             if !is_open {
                 is_open = true;
-                writeln!(f_out, "#ifdef MSVC" );
+                writeln!(out_str, "#ifdef MSVC").unwrap();
             }
-            writeln!(f_out, "{}", m_v[m_idx] );
+            writeln!(out_str, "{}", &m_v[m_idx]).unwrap();
             m_idx += 1;
             c_a += 1;
         }
     }
 }
-
-fn up_to_date(hash: u64, expected: &Path) -> Result<bool> {
-    let input = match std::fs::read_to_string(expected) {
-        Ok(i) => i,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(false),
-        Err(e) => return Err(e.into()),
-    };
-    let last = match input.lines().last() {
-        Some(l) => l,
-        None => return Ok(false),
-    };
-    let suffix = match last.strip_prefix("// hash: ") {
-        Some(s) => s,
-        None => return Ok(false),
-    };
-    match u64::from_str_radix(suffix, 16) {
-        Ok(n) if n == hash => Ok(true),
-        _ => Ok(false),
-    }
-}
-

--- a/repc/arocc/src/main.rs
+++ b/repc/arocc/src/main.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+use anyhow::{anyhow, bail, Context, Result};
+use cly_impl::ast::Declaration;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
+use repc_impl::target::{system_compiler, Compiler, Target, TARGETS};
+use repc_tests::{read_input_config, GlobalConfig, InputConfig};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{ErrorKind, Write};
+use std::path::Path;
+use std::process;
+use std::process::Command;
+
+#[path="../../test-generator/src/c.rs"]
+mod c;
+// mod dwarf;
+// mod pdb;
+
+fn main() {
+    if let Err(e) = main_() {
+        eprintln!("{:?}", e);
+        process::exit(1);
+    }
+}
+
+/// this is ugly ugly ugly code.
+/// it's only intended to be run once, to generate the test files
+/// for arocc. Don't judge me.
+fn main_() -> Result<()> {
+    // let userconfig: GlobalConfig = toml::from_str(&std::fs::read_to_string("config.toml")?)?;
+
+    let mut dirs = vec![];
+    for dir in std::fs::read_dir("testfiles").expect("Can't open testfiles dir") {
+        let dir = dir?;
+        if dir.file_type()?.is_dir() { //&& userconfig.test_test(dir.file_name().to_str().unwrap()) {
+            dirs.push(dir.path());
+        }
+    }
+    dirs.sort();
+    dirs.iter().for_each(|dir| {
+        let config = read_input_config(dir)
+            .with_context(|| anyhow!("cannot read config in {}", dir.display())).expect("aksljdh");
+        let input_path = dir.join("input.txt");
+        let input = std::fs::read_to_string(&input_path).expect("akjhsd");
+        // let hash = {
+        //     let mut hash = DefaultHasher::new();
+        //     input.hash(&mut hash);
+        //     config.0.hash(&mut hash);
+        //     hash.finish()
+        // };
+        let declarations = cly_impl::parse(&input)
+            .with_context(|| anyhow!("Parsing of {} failed", input_path.display())).expect("failed to parse input file");
+
+        let targets:Vec<_> = TARGETS.iter().filter(|t| { config.1.test_target(**t) }).collect();
+        let mut comps:HashSet<_> = targets.iter().map(|t|{system_compiler(**t)}).collect();
+
+        if comps.contains( &Compiler::Clang ) && comps.contains( &Compiler::Gcc ) {
+            comps.remove(&Compiler::Gcc);
+        }
+
+        let dir_name = dir.file_name().unwrap().to_str().unwrap();
+        let f_name = format!("{}_test.c",dir_name);
+        println!("{}",f_name);
+
+        let c_code = if comps.contains( &Compiler::Clang ) {
+            let (code, ids) = c::generate(&declarations,Compiler::Clang).unwrap();
+            Some(code)
+        } else {
+            None
+        };
+
+        let m_code = if comps.contains( &Compiler::Msvc ) {
+            let (code, ids) = c::generate(&declarations,Compiler::Msvc).unwrap();
+            Some(code)
+        } else {
+            None
+        };
+
+        match (c_code, m_code) {
+            (Some(c),None) => std::fs::write(f_name, c).expect("die die die"),
+            (None,Some(m)) => std::fs::write(f_name, m).expect("die die die"),
+            (Some(c), Some(m)) => merge_two(c,m,f_name),
+            (None, None) => unreachable!()
+        };
+
+
+
+
+
+    });
+    Ok(())
+}
+
+
+fn merge_two(c:String, m:String, f_name:String) {
+    let mut f_out = File::create(f_name).expect("die die die");
+    let mut c_idx = 0;
+    let mut m_idx = 0;
+    let c_v:Vec<_> = c.lines().map(|s|s.to_string()).collect();
+    let m_v:Vec<_> = m.lines().map(|s|s.to_string()).collect();
+    let mut c_a = 0;
+    let mut is_open = false;
+    while c_idx < c_v.len() && m_idx < m_v.len() {
+        if c_v[c_idx + c_a] == m_v[m_idx] {
+            if is_open {
+                writeln!(f_out, "#else" );
+                let cur = c_idx+c_a;
+                while c_idx < cur {
+                    writeln!(f_out, "{}", c_v[c_idx] );
+                    c_idx += 1;
+                    // println!("{} {}", c_idx, c_idx+c_a );
+                }
+                // println!("le");
+                writeln!(f_out, "#endif" );
+                is_open = false;
+                c_a = 0;
+            }
+            writeln!(f_out, "{}", c_v[c_idx] );
+            c_idx += 1;
+            m_idx += 1;
+        } else {
+            if !is_open {
+                is_open = true;
+                writeln!(f_out, "#ifdef MSVC" );
+            }
+            writeln!(f_out, "{}", m_v[m_idx] );
+            m_idx += 1;
+            c_a += 1;
+        }
+    }
+}
+
+fn up_to_date(hash: u64, expected: &Path) -> Result<bool> {
+    let input = match std::fs::read_to_string(expected) {
+        Ok(i) => i,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    let last = match input.lines().last() {
+        Some(l) => l,
+        None => return Ok(false),
+    };
+    let suffix = match last.strip_prefix("// hash: ") {
+        Some(s) => s,
+        None => return Ok(false),
+    };
+    match u64::from_str_radix(suffix, 16) {
+        Ok(n) if n == hash => Ok(true),
+        _ => Ok(false),
+    }
+}
+

--- a/repc/arocc/src/main.rs
+++ b/repc/arocc/src/main.rs
@@ -52,6 +52,9 @@ fn main() {
 /// this is ugly ugly ugly code.
 /// it's only intended to be run once, to generate the test files
 /// for arocc. Don't judge me.
+/// this is meant to be run in the /reprc/tests directory.
+/// you will also need a `mapping.txt` file in the same directoy.
+/// The zig code in /repr/arocc generrates this file.
 fn main_() -> std::io::Result<()> {
     let mut reprc_zig_map: HashMap<Target, String> = HashMap::new();
     {
@@ -108,7 +111,7 @@ fn main_() -> std::io::Result<()> {
         let f_name = format!("{}_test.c", dir_name);
         let mut out_str = "// SPDX-License-Identifier: GPL-3.0-or-later\n\n\
         // This test file is auto-generated. do not edit.\n\
-        // This file is a derivative work from the test files found\
+        // This file is a derivative work from the test files found\n\
         // in this repo : https://github.com/mahkoh/repr-c\n\
         // and is under the same licence as the original work.\n\n"
             .to_string();

--- a/repc/impl/build.rs
+++ b/repc/impl/build.rs
@@ -592,7 +592,7 @@ fn emit_targets() -> io::Result<()> {
 ///
 /// The notion of a target's system compiler matters because compilers generate slightly
 /// different layouts even on the same target.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash )]
 #[non_exhaustive]
 pub enum Target {{
 "

--- a/repc/impl/src/builder/sysv_like/mingw.rs
+++ b/repc/impl/src/builder/sysv_like/mingw.rs
@@ -11,6 +11,7 @@ pub(crate) fn compute_layout(target: Target, ty: &Type<()>) -> Result<Type<TypeL
     super::compute_layout(target, ty, Dialect::Mingw)
 }
 
+#[derive(Debug)]
 pub(super) struct OngoingBitfield {
     // The size of the storage unit of the previous bitfield. This is the size of the underlying
     // type, e.g., `int`.

--- a/repc/impl/src/builder/sysv_like/mod.rs
+++ b/repc/impl/src/builder/sysv_like/mod.rs
@@ -119,14 +119,12 @@ fn compute_record_layout(
         kind,
         ongoing_bitfield: None,
     };
-    // println!("rec_bl:{:?}\n\tan:{:?}\n\tf:{:?}", rlb, annotations, fields);
     match dialect {
         Dialect::Mingw => mingw::layout_fields(&mut rlb, fields)?,
         Dialect::Sysv => sysv::layout_fields(&mut rlb, fields)?,
     }
     // The size of a record is always a multiple of its alignment. See test case 0066.
     rlb.size_bits = align_to(rlb.size_bits, rlb.alignment_bits)?;
-    // println!("done:{:?}\n", rlb);
     Ok(Type {
         layout: TypeLayout {
             size_bits: rlb.size_bits,

--- a/repc/impl/src/builder/sysv_like/mod.rs
+++ b/repc/impl/src/builder/sysv_like/mod.rs
@@ -71,7 +71,7 @@ fn compute_layout(target: Target, ty: &Type<()>, dialect: Dialect) -> Result<Typ
         }
     }
 }
-
+#[derive(Debug)]
 struct RecordLayoutBuilder {
     target: Target,
     // The alignment of this record.
@@ -119,12 +119,14 @@ fn compute_record_layout(
         kind,
         ongoing_bitfield: None,
     };
+    // println!("rec_bl:{:?}\n\tan:{:?}\n\tf:{:?}", rlb, annotations, fields);
     match dialect {
         Dialect::Mingw => mingw::layout_fields(&mut rlb, fields)?,
         Dialect::Sysv => sysv::layout_fields(&mut rlb, fields)?,
     }
     // The size of a record is always a multiple of its alignment. See test case 0066.
     rlb.size_bits = align_to(rlb.size_bits, rlb.alignment_bits)?;
+    // println!("done:{:?}\n", rlb);
     Ok(Type {
         layout: TypeLayout {
             size_bits: rlb.size_bits,

--- a/repc/impl/src/builder/sysv_like/sysv.rs
+++ b/repc/impl/src/builder/sysv_like/sysv.rs
@@ -28,6 +28,7 @@ pub(super) fn layout_fields(
 
 fn layout_field(rlb: &mut RecordLayoutBuilder, field: &RecordField<()>) -> Result<()> {
     let ty = super::compute_layout(rlb.target, &field.ty, Dialect::Sysv)?;
+    // println!("fld_ty:{:?}", ty);
     let layout = match field.bit_width {
         Some(size_bits) => layout_bit_field(
             rlb,
@@ -80,6 +81,7 @@ fn layout_bit_field(
     let attr_packed = rlb.attr_packed || is_attr_packed(&field.annotations);
     let has_packing_annotations = attr_packed || rlb.max_field_alignment_bits.is_some();
     let annotation_alignment = annotation_alignment(rlb.target, &field.annotations).unwrap_or(1);
+    // println!("saa:{}\n", annotation_alignment);
     let first_unused_bit = match rlb.kind {
         RecordKind::Union => 0,
         RecordKind::Struct => rlb.size_bits,
@@ -141,6 +143,13 @@ fn layout_bit_field(
             inherited_alignment_bits = ty_field_alignment_bits
                 .max(annotation_alignment)
                 .min(max_field_alignment_bits);
+            // println!(
+            //     "in:{} aa:{} tfa:{} mxfa:{}",
+            //     inherited_alignment_bits,
+            //     annotation_alignment,
+            //     ty_field_alignment_bits,
+            //     max_field_alignment_bits
+            // );
         } else if attr_packed {
             // Otherwise, if the field or the record is packed, the field alignment is 1 bit unless
             // it is explicitly increased with __attribute__((aligned)). See test case 0077.

--- a/repc/impl/src/builder/sysv_like/sysv.rs
+++ b/repc/impl/src/builder/sysv_like/sysv.rs
@@ -28,7 +28,6 @@ pub(super) fn layout_fields(
 
 fn layout_field(rlb: &mut RecordLayoutBuilder, field: &RecordField<()>) -> Result<()> {
     let ty = super::compute_layout(rlb.target, &field.ty, Dialect::Sysv)?;
-    // println!("fld_ty:{:?}", ty);
     let layout = match field.bit_width {
         Some(size_bits) => layout_bit_field(
             rlb,
@@ -81,7 +80,6 @@ fn layout_bit_field(
     let attr_packed = rlb.attr_packed || is_attr_packed(&field.annotations);
     let has_packing_annotations = attr_packed || rlb.max_field_alignment_bits.is_some();
     let annotation_alignment = annotation_alignment(rlb.target, &field.annotations).unwrap_or(1);
-    // println!("saa:{}\n", annotation_alignment);
     let first_unused_bit = match rlb.kind {
         RecordKind::Union => 0,
         RecordKind::Struct => rlb.size_bits,
@@ -143,13 +141,6 @@ fn layout_bit_field(
             inherited_alignment_bits = ty_field_alignment_bits
                 .max(annotation_alignment)
                 .min(max_field_alignment_bits);
-            // println!(
-            //     "in:{} aa:{} tfa:{} mxfa:{}",
-            //     inherited_alignment_bits,
-            //     annotation_alignment,
-            //     ty_field_alignment_bits,
-            //     max_field_alignment_bits
-            // );
         } else if attr_packed {
             // Otherwise, if the field or the record is packed, the field alignment is 1 bit unless
             // it is explicitly increased with __attribute__((aligned)). See test case 0077.

--- a/repc/impl/src/target.rs
+++ b/repc/impl/src/target.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Compiler {
     Msvc,
     Gcc,

--- a/repc/impl/src/util.rs
+++ b/repc/impl/src/util.rs
@@ -131,7 +131,7 @@ impl MaxExt<u64> for Option<u64> {
     }
 }
 
-pub(crate) fn align_to(n: u64, m: u64) -> Result<u64> {
+pub fn align_to(n: u64, m: u64) -> Result<u64> {
     assert!(m.is_power_of_two());
     let mask = m - 1;
     match n.checked_add(mask) {

--- a/repc/tests/src/tests.rs
+++ b/repc/tests/src/tests.rs
@@ -46,21 +46,27 @@ fn process_dir(
     global_config: &GlobalConfig,
     failed: &Mutex<Vec<String>>,
 ) -> Result<()> {
+    // if !dir.to_str().unwrap().contains("0068") {
+    //     return Ok(());
+    // }
     let config = read_input_config(dir)?.1;
     let input_path = dir.join("input.txt");
     let input = std::fs::read_to_string(&input_path)?;
     let declarations = cly_impl::parse(&input).context("Parsing failed")?;
-    TARGETS.par_iter().try_for_each(|target| {
-        if !process_target(&dir, &input, &declarations, *target, &config, global_config)
-            .with_context(|| anyhow!("processing target {} failed", target.name()))?
-        {
-            failed
-                .lock()
-                .unwrap()
-                .push(format!("{}/{}", dir.display(), target.name()));
-        }
-        Ok(())
-    })
+    TARGETS
+        .iter()
+        // .filter(|x| x == &&Target::X86_64UnknownLinuxGnu)
+        .try_for_each(|target| {
+            if !process_target(&dir, &input, &declarations, *target, &config, global_config)
+                .with_context(|| anyhow!("processing target {} failed", target.name()))?
+            {
+                failed
+                    .lock()
+                    .unwrap()
+                    .push(format!("{}/{}", dir.display(), target.name()));
+            }
+            Ok(())
+        })
 }
 
 fn process_target(

--- a/repc/tests/src/tests.rs
+++ b/repc/tests/src/tests.rs
@@ -46,9 +46,6 @@ fn process_dir(
     global_config: &GlobalConfig,
     failed: &Mutex<Vec<String>>,
 ) -> Result<()> {
-    // if !dir.to_str().unwrap().contains("0068") {
-    //     return Ok(());
-    // }
     let config = read_input_config(dir)?.1;
     let input_path = dir.join("input.txt");
     let input = std::fs::read_to_string(&input_path)?;


### PR DESCRIPTION
1) Switch to using StringArrayHashMap instead of StringHashMap for the rust<->zig target mapping, so that we can iterate over the items deterministically. Makes it easier to spot differences if anything changes

2) We were using `eabi` for some ABIs instead of `none`. This checks if "none" is the last component of a triple and sets the ABI to `.none` if so.

3) A few spelling / formatting fixes.