### PR TITLE
layout tests: skip int128 tests for other unsupported platforms

### DIFF
--- a/repc/tests/testfiles/0050/config.toml
+++ b/repc/tests/testfiles/0050/config.toml
@@ -61,4 +61,7 @@ exclude_targets = [
     "thumbv8m.base-none-eabi",
     "thumbv8m.main-none-eabi",
     "thumbv8m.main-none-eabihf",
+    "mipsisa64r6el-unknown-linux-gnuabi64",
+    "mipsisa64r6-unknown-linux-gnuabi64",
+    "sparcv9-sun-solaris",
 ]


### PR DESCRIPTION
Exclude:
        mipsisa64r6el-unknown-linux-gnuabi64
        mipsisa64r6-unknown-linux-gnuabi64
        sparcv9-sun-solaris